### PR TITLE
fix: Query server_version when connection is made

### DIFF
--- a/lib/appmap/handler/rails/request_handler.rb
+++ b/lib/appmap/handler/rails/request_handler.rb
@@ -100,15 +100,14 @@ module AppMap
 
           protected
 
-          def before_hook(receiver, defined_class, _) # args
+          def before_hook(receiver, *)
             call_event = HTTPServerRequest.new(receiver.request)
             # http_server_request events are i/o and do not require a package name.
             AppMap.tracing.record_event call_event, defined_class: defined_class, method: hook_method
-            [ call_event, TIME_NOW.call ]
+            call_event
           end
 
-          def after_hook(receiver, call_event, start_time, _, _) # return_value, exception
-            elapsed = TIME_NOW.call - start_time
+          def after_hook(receiver, call_event, elapsed, *)
             return_event = HTTPServerResponse.new receiver.response, call_event.id, elapsed
             AppMap.tracing.record_event return_event
           end

--- a/lib/appmap/handler/rails/sql_handler.rb
+++ b/lib/appmap/handler/rails/sql_handler.rb
@@ -69,7 +69,8 @@ module AppMap
 
           class SequelExaminer
             def server_version
-              Sequel::Model.db.server_version
+              # Sequel::Model.db.server_version
+              1234
             end
 
             def database_type

--- a/lib/appmap/handler/rails/sql_handler.rb
+++ b/lib/appmap/handler/rails/sql_handler.rb
@@ -2,6 +2,15 @@
 
 require 'appmap/event'
 
+if defined?(Sequel)
+  Sequel::Database.after_initialize do |db|
+    # Sequel memoizes server_version. Calling it here ensures that it
+    # will be available to SequelExaminer, without requiring that a
+    # query be executed to get it.
+    db.server_version
+  end
+end
+
 module AppMap
   module Handler
     module Rails


### PR DESCRIPTION
**DO NOT MERGE THIS**  until [f8461bb](https://github.com/applandinc/appmap-ruby/pull/241/commits/f8461bb0285a3ce1bce12f3f91bd245a66159489) has been removed.

Add a Sequel::Database.after_initialize hook to cache server_version
when a connection gets initialized. This ensures that we won't try to
execute a query to get it while Sequel is executing another query.