### PR TITLE
feat: Record AppMap's overhead in `elapsed_instrumentation`

### DIFF
--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -262,7 +262,7 @@ module AppMap
     end
 
     class MethodReturnIgnoreValue < MethodEvent
-      attr_accessor :parent_id, :elapsed
+      attr_accessor :parent_id, :elapsed, :elapsed_instrumentation
 
       class << self
         def build_from_invocation(parent_id, elapsed: nil, event: MethodReturnIgnoreValue.new)
@@ -279,6 +279,7 @@ module AppMap
         super.tap do |h|
           h[:parent_id] = parent_id
           h[:elapsed] = elapsed if elapsed
+          h[:elapsed_instrumentation] = elapsed_instrumentation if elapsed_instrumentation
         end
       end
     end

--- a/lib/appmap/handler/rails/request_handler.rb
+++ b/lib/appmap/handler/rails/request_handler.rb
@@ -10,7 +10,7 @@ module AppMap
 
       module RequestHandler
         class HTTPServerRequest < AppMap::Event::MethodEvent
-          attr_accessor :normalized_path_info, :request_method, :path_info, :params, :headers
+          attr_accessor :normalized_path_info, :request_method, :path_info, :params, :headers, :call_elapsed_instrumentation
 
           def initialize(request)
             super AppMap::Event.next_id_counter, :call, Thread.current.object_id
@@ -101,16 +101,21 @@ module AppMap
           protected
 
           def before_hook(receiver, *)
+            before_hook_start_time = AppMap::Util.gettime()
             call_event = HTTPServerRequest.new(receiver.request)
+            call_event.call_elapsed_instrumentation = (AppMap::Util.gettime() - before_hook_start_time)
             # http_server_request events are i/o and do not require a package name.
             AppMap.tracing.record_event call_event, defined_class: defined_class, method: hook_method
             call_event
           end
 
           def after_hook(receiver, call_event, elapsed, *)
+            after_hook_start_time = AppMap::Util.gettime()
             return_value = Thread.current[TEMPLATE_RENDER_VALUE]
             Thread.current[TEMPLATE_RENDER_VALUE] = nil
             return_event = HTTPServerResponse.build_from_invocation call_event.id, return_value, elapsed, receiver.response
+            return_event.elapsed_instrumentation = (AppMap::Util.gettime() - after_hook_start_time) + call_event.call_elapsed_instrumentation
+            call_event.call_elapsed_instrumentation = nil # to stay consistent with elapsed_instrumentation only being stored in return
             AppMap.tracing.record_event return_event
           end
         end

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -102,8 +102,9 @@ module AppMap
         @defined_class ||= Hook.qualify_method_name(hook_method)&.first
       end
 
-      def after_hook(_receiver, call_event, elapsed, return_value, exception)
+      def after_hook(_receiver, call_event, elapsed_before, elapsed, after_start_time, return_value, exception)
         return_event = handle_return(call_event.id, elapsed, return_value, exception)
+        return_event.elapsed_instrumentation = elapsed_before + (gettime - after_start_time)
         AppMap.tracing.record_event(return_event) if return_event
       end
 

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'appmap/util'
+
 module AppMap
   class Hook
     SIGNATURES = {}
@@ -78,10 +80,6 @@ module AppMap
         warn "#{hook_method.name} not found on #{hook_class}" if Hook::LOG
       end
 
-      def gettime
-        Process.clock_gettime Process::CLOCK_MONOTONIC
-      end
-
       def trace?
         return false unless AppMap.tracing_enabled?
         return false if Thread.current[HOOK_DISABLE_KEY]
@@ -104,7 +102,7 @@ module AppMap
 
       def after_hook(_receiver, call_event, elapsed_before, elapsed, after_start_time, return_value, exception)
         return_event = handle_return(call_event.id, elapsed, return_value, exception)
-        return_event.elapsed_instrumentation = elapsed_before + (gettime - after_start_time)
+        return_event.elapsed_instrumentation = elapsed_before + (AppMap::Util.gettime() - after_start_time)
         AppMap.tracing.record_event(return_event) if return_event
       end
 

--- a/lib/appmap/hook/method/ruby2.rb
+++ b/lib/appmap/hook/method/ruby2.rb
@@ -8,15 +8,19 @@ module AppMap
     # cf. https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html
     class Method
       ruby2_keywords def call(receiver, *args, &block)
-        call_event = trace? && with_disabled_hook { before_hook receiver, *args }
+        call_event = false
+        if trace?
+          call_event, elapsed_before = with_disabled_hook { before_hook receiver, *args }
+        end
         # note we can't short-circuit directly to do_call because then the call stack
         # depth changes and eval handler doesn't work correctly
-        trace_call call_event, receiver, *args, &block
+        trace_call call_event, elapsed_before, receiver, *args, &block
       end
 
       protected
 
       def before_hook(receiver, *args)
+        before_hook_start_time = gettime
         call_event = handle_call(receiver, args)
         if call_event
           AppMap.tracing.record_event \
@@ -25,7 +29,7 @@ module AppMap
             defined_class: defined_class,
             method: hook_method
         end
-        call_event
+        [call_event, gettime - before_hook_start_time]
       end
 
       ruby2_keywords def do_call(receiver, *args, &block)
@@ -33,7 +37,7 @@ module AppMap
       end
 
       # rubocop:disable Metrics/MethodLength
-      ruby2_keywords def trace_call(call_event, receiver, *args, &block)
+      ruby2_keywords def trace_call(call_event, elapsed_before, receiver, *args, &block)
         return do_call(receiver, *args, &block) unless call_event
 
         start_time = gettime
@@ -43,7 +47,8 @@ module AppMap
           exception = $ERROR_INFO
           raise
         ensure
-          with_disabled_hook { after_hook receiver, call_event, gettime - start_time, return_value, exception } \
+          after_start_time = gettime
+          with_disabled_hook { after_hook receiver, call_event, elapsed_before, after_start_time - start_time, after_start_time, return_value, exception } \
             if call_event
         end
       end

--- a/lib/appmap/hook/method/ruby2.rb
+++ b/lib/appmap/hook/method/ruby2.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'appmap/util'
+
 def ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)
 
 module AppMap
@@ -20,7 +22,7 @@ module AppMap
       protected
 
       def before_hook(receiver, *args)
-        before_hook_start_time = gettime
+        before_hook_start_time = AppMap::Util.gettime()
         call_event = handle_call(receiver, args)
         if call_event
           AppMap.tracing.record_event \
@@ -29,7 +31,7 @@ module AppMap
             defined_class: defined_class,
             method: hook_method
         end
-        [call_event, gettime - before_hook_start_time]
+        [call_event, AppMap::Util.gettime() - before_hook_start_time]
       end
 
       ruby2_keywords def do_call(receiver, *args, &block)
@@ -40,14 +42,14 @@ module AppMap
       ruby2_keywords def trace_call(call_event, elapsed_before, receiver, *args, &block)
         return do_call(receiver, *args, &block) unless call_event
 
-        start_time = gettime
+        start_time = AppMap::Util.gettime()
         begin
           return_value = do_call(receiver, *args, &block)
         rescue # rubocop:disable Style/RescueStandardError
           exception = $ERROR_INFO
           raise
         ensure
-          after_start_time = gettime
+          after_start_time = AppMap::Util.gettime()
           with_disabled_hook { after_hook receiver, call_event, elapsed_before, after_start_time - start_time, after_start_time, return_value, exception } \
             if call_event
         end

--- a/lib/appmap/hook/method/ruby3.rb
+++ b/lib/appmap/hook/method/ruby3.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'appmap/util'
+
 module AppMap
   class Hook
     # Delegation methods for Ruby 3.
@@ -17,7 +19,7 @@ module AppMap
       protected
 
       def before_hook(receiver, *args, **kwargs)
-        before_hook_start_time = gettime
+        before_hook_start_time = AppMap::Util.gettime()
         args = [*args, kwargs] if !kwargs.empty? || keyrest?
         call_event = handle_call(receiver, args)
         if call_event
@@ -27,7 +29,7 @@ module AppMap
             defined_class: defined_class,
             method: hook_method
         end
-        [call_event, gettime - before_hook_start_time]
+        [call_event, AppMap::Util.gettime() - before_hook_start_time]
       end
 
       def keyrest?
@@ -42,14 +44,14 @@ module AppMap
       def trace_call(call_event, elapsed_before, receiver, *args, **kwargs, &block)
         return do_call(receiver, *args, **kwargs, &block) unless call_event
 
-        start_time = gettime
+        start_time = AppMap::Util.gettime()
         begin
           return_value = do_call(receiver, *args, **kwargs, &block)
         rescue # rubocop:disable Style/RescueStandardError
           exception = $ERROR_INFO
           raise
         ensure
-          after_start_time = gettime
+          after_start_time = AppMap::Util.gettime()
           with_disabled_hook { after_hook receiver, call_event, elapsed_before, after_start_time - start_time, after_start_time, return_value, exception } \
             if call_event
         end

--- a/lib/appmap/hook/method/ruby3.rb
+++ b/lib/appmap/hook/method/ruby3.rb
@@ -5,15 +5,19 @@ module AppMap
     # Delegation methods for Ruby 3.
     class Method
       def call(receiver, *args, **kwargs, &block)
-        call_event = trace? && with_disabled_hook { before_hook receiver, *args, **kwargs }
+        call_event = false
+        if trace?
+          call_event, elapsed_before = with_disabled_hook { before_hook receiver, *args, **kwargs }
+        end
         # note we can't short-circuit directly to do_call because then the call stack
         # depth changes and eval handler doesn't work correctly
-        trace_call call_event, receiver, *args, **kwargs, &block
+        trace_call call_event, elapsed_before, receiver, *args, **kwargs, &block
       end
 
       protected
 
       def before_hook(receiver, *args, **kwargs)
+        before_hook_start_time = gettime
         args = [*args, kwargs] if !kwargs.empty? || keyrest?
         call_event = handle_call(receiver, args)
         if call_event
@@ -23,7 +27,7 @@ module AppMap
             defined_class: defined_class,
             method: hook_method
         end
-        call_event
+        [call_event, gettime - before_hook_start_time]
       end
 
       def keyrest?
@@ -35,7 +39,7 @@ module AppMap
       end
 
       # rubocop:disable Metrics/MethodLength
-      def trace_call(call_event, receiver, *args, **kwargs, &block)
+      def trace_call(call_event, elapsed_before, receiver, *args, **kwargs, &block)
         return do_call(receiver, *args, **kwargs, &block) unless call_event
 
         start_time = gettime
@@ -45,7 +49,8 @@ module AppMap
           exception = $ERROR_INFO
           raise
         ensure
-          with_disabled_hook { after_hook receiver, call_event, gettime - start_time, return_value, exception } \
+          after_start_time = gettime
+          with_disabled_hook { after_hook receiver, call_event, elapsed_before, after_start_time - start_time, after_start_time, return_value, exception } \
             if call_event
         end
       end

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -86,6 +86,7 @@ module AppMap
       def sanitize_event(event, &block)
         event.delete(:thread_id)
         event.delete(:elapsed)
+        event.delete(:elapsed_instrumentation)
         delete_object_id = ->(obj) { (obj || {}).delete(:object_id) }
         delete_object_id.call(event[:receiver])
         delete_object_id.call(event[:return_value])

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -232,6 +232,10 @@ module AppMap
       def ruby_minor_version
         @ruby_minor_version ||= RUBY_VERSION.split('.')[0..1].join('.').to_f
       end
+
+      def gettime
+        Process.clock_gettime Process::CLOCK_MONOTONIC
+      end
     end
   end
 end


### PR DESCRIPTION
Record AppMap's overhead before a function call and after a function call, and save this data in the event.
Do this for:
- function calls
- sql queries
- http requests

Generating this data makes it possible to display a [report](https://github.com/applandinc/appmap-js/pull/721) of functions with the highest AppMap overhead. 

Addresses https://github.com/applandinc/board/issues/140

Before
```
npm start stats -- /home/test/src/sample_app_6th_ed --limit 200 
0000000000s DELETE /relationships/980190962 1 calls
0000000000s GET /login 3 calls
0000000000s GET /about 1 calls
0000000000s GET /contact 1 calls
0000000000s GET /help 1 calls
0000000000s GET /signup 3 calls
0000000000s DELETE /users/762146111 2 calls
0000000000s GET /users/762146111/edit 4 calls
```

After
```
0.00451700s POST /login 21 calls
0.00067000s POST /microposts 3 calls
0.00066300s POST /relationships 3 calls
0.00057800s POST /password_resets 3 calls
0.00041400s POST /users 2 calls
0.00021800s DELETE /microposts/1033843181 1 calls
0.00020300s DELETE /microposts/583546149 1 calls
0.00020200s DELETE /microposts/499495288 1 calls
```