### PR TITLE
fix: Drop database server version

### DIFF
--- a/lib/appmap/handler/rails/sql_handler.rb
+++ b/lib/appmap/handler/rails/sql_handler.rb
@@ -75,7 +75,6 @@ module AppMap
                 end
               end
 
-              payload[:server_version] = examiner.server_version
               payload[:database_type] = examiner.database_type.to_s
             end
 
@@ -92,6 +91,8 @@ module AppMap
 
           class SequelExaminer
             def server_version
+              # Queries the database, therefore this is pretty unsafe to do inside of a hook.
+              # As a result, this is not being used at the moment.
               Sequel::Model.db.server_version
             end
 

--- a/spec/record_sql_rails_pg_spec.rb
+++ b/spec/record_sql_rails_pg_spec.rb
@@ -56,7 +56,7 @@ describe 'SQL events' do
 
       RSpec::Matchers.define_negated_matcher :not_include, :include
       def sql_query(query)
-        (include('sql_query' => (include 'sql' => query)))
+        (include('sql_query' => (include 'sql' => query, 'database_type' => 'postgres')))
           .and(not_include('defined_class'))
           .and(not_include('method_id'))
           .and(not_include('path'))


### PR DESCRIPTION
It's unsafe to query the DB for the version when already inside of a hook.

I experimented with various ways of querying the DB outside of hooks, but they are all super-hacky and I don't think it's worth the effort since there is nothing downstream that depends on the `server_version` being present. This field is optional in the spec.
