### PR TITLE
fix: Add language, appmap_dir to generated appmap.yml

### DIFF
--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -346,6 +346,8 @@ module AppMap
         load(config_data).tap do |config|
           {
             'name' => config.name,
+            'language' => 'ruby',
+            'appmap_dir' => AppMap::DEFAULT_APPMAP_DIR,
             'packages' => config.packages.select{|p| p.path}.map do |pkg|
               { 'path' => pkg.path }
             end,


### PR DESCRIPTION
When appmap.yml does not exist, a default file is generated. Include language and appmap_dir in this file.