### PR TITLE
Record all tests by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 AllCops:
   NewCops: enable
 
+# The gem is automatically pushed by CI
+Gemspec/RequireMFA:
+  Enabled: false
+
 Layout/CaseIndentation:
   EnforcedStyle: end
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
 Gemspec/RequireMFA:
   Enabled: false
 
+Layout/ArrayAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/CaseIndentation:
   EnforcedStyle: end
 

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -7,26 +7,25 @@ require 'appmap/version'
 Gem::Specification.new do |spec|
   # ability to parameterize gem name is added intentionally,
   # to support the possibility of unofficial releases, e.g. during CI tests
-  spec.name          = (ENV['GEM_ALTERNATIVE_NAME'].to_s.empty? ? 'appmap' : ENV["GEM_ALTERNATIVE_NAME"] )
+  spec.name          = ENV.fetch('GEM_ALTERNATIVE_NAME', 'appmap')
   spec.version       = AppMap::VERSION
   spec.authors       = ['Kevin Gilpin']
   spec.email         = ['kgilpin@gmail.com']
 
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.summary       = %q{Record the operation of a Ruby program, using the AppLand 'AppMap' format.}
+  spec.summary       = "Record the operation of a Ruby program, using the AppLand 'AppMap' format."
   spec.homepage      = AppMap::URL
   spec.license       = 'MIT'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = `git ls-files --no-deleted`.split("
-").grep_v(/appmap\.json$/).grep_v(/^spec\//).grep_v(/^test\//)
+  spec.files         = `git ls-files --no-deleted`.split("\n").grep_v(/appmap\.json$/).grep_v(%r{^(spec|test)/})
 
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  spec.extensions << "ext/appmap/extconf.rb"
+  spec.extensions << 'ext/appmap/extconf.rb'
   spec.require_paths = ['lib']
 
   spec.add_dependency 'method_source'
@@ -39,19 +38,19 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.15'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'rubocop', '~> 1.36'
-  spec.add_development_dependency 'rake-compiler'
 
   # Testing
   spec.add_development_dependency 'climate_control'
   spec.add_development_dependency 'diffy'
+  spec.add_development_dependency 'hashie'
   spec.add_development_dependency 'launchy'
+  spec.add_development_dependency 'random-port', '~> 0.5.1'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'selenium-webdriver'
-  spec.add_development_dependency 'webdrivers', '~> 4.0'
   spec.add_development_dependency 'timecop'
-  spec.add_development_dependency 'hashie'
-  spec.add_development_dependency 'random-port', '~> 0.5.1'
+  spec.add_development_dependency 'webdrivers', '~> 4.0'
   spec.add_development_dependency 'webrick'
 end

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rdoc'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'rake-compiler'
 
   # Testing

--- a/lib/appmap/detect_enabled.rb
+++ b/lib/appmap/detect_enabled.rb
@@ -39,7 +39,14 @@ module AppMap
     end
 
     def detect_enabled
-      detection_functions = %i[globally_disabled? recording_method_disabled? enabled_by_app_env? recording_method_enabled? globally_enabled?]
+      detection_functions = %i[
+        globally_disabled?
+        recording_method_disabled?
+        enabled_by_testing?
+        enabled_by_app_env?
+        recording_method_enabled?
+        globally_enabled?
+      ]
 
       message, enabled = []
       while enabled.nil? && !detection_functions.empty?
@@ -54,12 +61,14 @@ module AppMap
       end
     end
 
+    def enabled_by_testing?
+      if %i[rspec minitest cucumber].member?(@recording_method)
+        [ "running tests with #{@recording_method}", true ]
+      end
+    end
+
     def enabled_by_app_env?
       env_name, app_env = detect_app_env
-      if %i[rspec minitest cucumber].member?(@recording_method)
-        return [ "#{env_name} is '#{app_env}'", true ] if app_env == 'test'
-      end
-
       if @recording_method.nil?
         return [ "#{env_name} is '#{app_env}'", true ] if %w[test development].member?(app_env)
       end
@@ -104,7 +113,7 @@ module AppMap
 
     def rails_env
       return Rails.env if defined?(::Rails::Railtie)
-      
+
       return ENV['RAILS_ENV']
     end
   end

--- a/spec/detect_enabled_spec.rb
+++ b/spec/detect_enabled_spec.rb
@@ -16,8 +16,8 @@ describe AppMap::DetectEnabled do
   }
 
   test_scenarios = {
-    disabled: [[], %w[RAILS_ENV=development], %w[APPMAP=false RAILS_ENV=development]],
-    enabled: [%w[APPMAP=true], %w[APPMAP_RECORD_@=true], %w[RAILS_ENV=test], %w[APP_ENV=test]]
+    disabled: [%w[APPMAP_RECORD_@=false], %w[APPMAP=true APPMAP_RECORD_@=false]],
+    enabled: [[], %w[APPMAP=true], %w[APPMAP_RECORD_@=true], %w[RAILS_ENV=test], %w[APP_ENV=development]]
   }
 
   before(:each) { AppMap::DetectEnabled.clear_cache }

--- a/spec/detect_enabled_spec.rb
+++ b/spec/detect_enabled_spec.rb
@@ -4,142 +4,42 @@ require 'spec_helper'
 require 'appmap/detect_enabled'
 
 describe AppMap::DetectEnabled do
+  nil_scenarios = {
+    disabled: [[], %w[APPMAP=false RAILS_ENV=development]],
+    enabled: [%w[APPMAP=true], %w[RAILS_ENV=development], %w[APP_ENV=development]]
+  }
+
+  http_scenarios = {
+    disabled: [[], %w[RAILS_ENV=test], %w[APPMAP=false RAILS_ENV=development],
+      %w[APPMAP_RECORD_@=false RAILS_ENV=development]],
+    enabled: [%w[APPMAP=true], %w[APPMAP_RECORD_@=true], %w[RAILS_ENV=development], %w[APP_ENV=development]]
+  }
+
+  test_scenarios = {
+    disabled: [[], %w[RAILS_ENV=development], %w[APPMAP=false RAILS_ENV=development]],
+    enabled: [%w[APPMAP=true], %w[APPMAP_RECORD_@=true], %w[RAILS_ENV=test], %w[APP_ENV=test]]
+  }
+
   before(:each) { AppMap::DetectEnabled.clear_cache }
 
-  shared_examples_for 'disabled' do
-    it do
-      expect(AppMap::DetectEnabled.new(recording_method).enabled?).to be(false)
-    end
-  end
-  shared_examples_for 'enabled' do
-    it do
-      expect(AppMap::DetectEnabled.new(recording_method).enabled?).to be(true)
+  def self.describe_method(recording_method, disabled:, enabled:)
+    describe "with #{recording_method || 'nil'} recording method" do
+      let(:recording_method) { recording_method }
+      disabled.each { |env| env_example env, recording_method, false }
+      enabled.each { |env| env_example env, recording_method, true }
     end
   end
 
-  describe 'recording_method' do
-    describe 'nil' do
-      let(:recording_method) { nil }
-      it_should_behave_like 'disabled'
-
-      describe 'APPMAP=true' do
-        before(:each) do
-          stub_const('ENV', ENV.to_hash.merge('APPMAP' => 'true'))
-        end
-        it_should_behave_like 'enabled'
-      end
-      describe 'RAILS_ENV=development' do
-        before(:each) do
-          stub_const('ENV', ENV.to_hash.merge('RAILS_ENV' => 'development'))
-        end
-        it_should_behave_like 'enabled'
-      end
-      describe 'APP_ENV=development' do
-        before(:each) do
-          stub_const('ENV', ENV.to_hash.merge('APP_ENV' => 'development'))
-        end
-        it_should_behave_like 'enabled'
-      end
-      describe 'APPMAP=false and RAILS_ENV=development' do
-        before(:each) do
-          stub_const('ENV', ENV.to_hash.merge('APPMAP' => 'false', 'RAILS_ENV' => 'development'))
-        end
-        it_should_behave_like 'disabled'
-      end
-    end
-
-    %w[remote requests].each do |recording_method|
-      describe recording_method do
-        let(:recording_method) { recording_method.to_sym }
-        it_should_behave_like 'disabled'
-
-        describe 'APPMAP=true' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('APPMAP' => 'true'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'APPMAP_RECORD_<recording_method>=true' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge("APPMAP_RECORD_#{recording_method.upcase}" => 'true'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'RAILS_ENV=development' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('RAILS_ENV' => 'development'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'APP_ENV=development' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('APP_ENV' => 'development'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'RAILS_ENV=test' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('RAILS_ENV' => 'test'))
-          end
-          it_should_behave_like 'disabled'
-        end
-        describe 'APPMAP=false and RAILS_ENV=development' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('APPMAP' => 'false', 'RAILS_ENV' => 'development'))
-          end
-          it_should_behave_like 'disabled'
-        end
-        describe 'APPMAP_RECORD_<recording_method>=false and RAILS_ENV=development' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge("APPMAP_RECORD_#{recording_method.upcase}" => 'false', 'RAILS_ENV' => 'development'))
-          end
-          it_should_behave_like 'disabled'
-        end
-      end
-    end
-
-    %w[rspec minitest cucumber].each do |test_framework|
-      describe test_framework do
-        let(:recording_method) { test_framework.to_sym }
-        it_should_behave_like 'disabled'
-
-        describe 'APPMAP=true' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('APPMAP' => 'true'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'APPMAP_RECORD_<framework>=true' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge("APPMAP_RECORD_#{test_framework.upcase}" => 'true'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'RAILS_ENV=development' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('RAILS_ENV' => 'development'))
-          end
-          it_should_behave_like 'disabled'
-        end
-        describe 'RAILS_ENV=test' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('RAILS_ENV' => 'test'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'APP_ENV=test' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('APP_ENV' => 'test'))
-          end
-          it_should_behave_like 'enabled'
-        end
-        describe 'APPMAP=false and RAILS_ENV=development' do
-          before(:each) do
-            stub_const('ENV', ENV.to_hash.merge('APPMAP' => 'false', 'RAILS_ENV' => 'development'))
-          end
-          it_should_behave_like 'disabled'
-        end
-        end
+  def self.env_example(env, recording_method, enabled)
+    env = env.map { |e| e.sub '@', recording_method.to_s.upcase }
+    it "is #{enabled ? 'enabled' : 'disabled'} with #{env.join ' '}" do
+      stub_const 'ENV', (env.to_h { |e| e.split '=' })
+      expect(AppMap::DetectEnabled.new(recording_method))
+        .send enabled ? :to : :to_not, be_enabled
     end
   end
+
+  describe_method nil, **nil_scenarios
+  %i[remote requests].each { |m| describe_method m, **http_scenarios }
+  %i[rspec minitest cucumber].each { |m| describe_method m, **test_scenarios }
 end

--- a/test/rspec_test.rb
+++ b/test/rspec_test.rb
@@ -11,7 +11,7 @@ class RSpecTest < Minitest::Test
         FileUtils.rm_rf 'tmp'
         system 'bundle config --local local.appmap ../../..'
         system 'bundle'
-        system({ 'APPMAP_RECORD_RSPEC' => 'true'}, %(bundle exec rspec spec/#{test_name}.rb))
+        system(%(bundle exec rspec spec/#{test_name}.rb))
 
         yield
       end


### PR DESCRIPTION
If we want to have recording by default, I think this makes more sense and is what user would expect: appmap is enabled by default whenever tests are run, regardless of environment variables (which might not even be set, even for example for rails — it only uses them as one input to determine environment).

It can still be disabled with `APPMAP=false` or `APPMAP_RECORD_RSPEC=false`.

Fixes #288 