### PR TITLE
fix: Don't check for rails anymore in appmap-agent-validate

### DIFF
--- a/lib/appmap/service/validator/config_validator.rb
+++ b/lib/appmap/service/validator/config_validator.rb
@@ -21,7 +21,6 @@ module AppMap
         def valid?
           @violations = []
           validate_ruby_version
-          validate_rails_presence
           validate_config_presence
           parse_config
           validate_config_load
@@ -65,14 +64,6 @@ module AppMap
             @violations << Violation.error(
               filename: @config_file,
               message: "AppMap configuration #{@config_file} file does not exist"
-            )
-          end
-        end
-
-        def validate_rails_presence
-          unless Gem.loaded_specs.has_key?('rails')
-            @violations << Violation.error(
-              message: 'AppMap auto-configuration is currently not available for non Rails projects'
             )
           end
         end

--- a/spec/service/config_analyzer_spec.rb
+++ b/spec/service/config_analyzer_spec.rb
@@ -28,7 +28,7 @@ describe AppMap::Service::ConfigAnalyzer do
     end
   end
 
-  context 'with valid but non rails config' do
+  context 'with valid config' do
     let(:config_file) { 'spec/fixtures/config/valid_config.yml'}
 
     describe '.app_name' do
@@ -37,8 +37,10 @@ describe AppMap::Service::ConfigAnalyzer do
       end
     end
 
-    it 'is valid' do
-      expect(subject.errors).to eq(['AppMap auto-configuration is currently not available for non Rails projects'])
+    describe '.is_valid?' do
+      it 'returns true' do
+        expect(subject.valid?).to be_truthy
+      end
     end
 
     describe '.is_present?' do
@@ -51,8 +53,8 @@ describe AppMap::Service::ConfigAnalyzer do
   context 'with maximal valid config' do
     let(:config_file) { 'spec/fixtures/config/maximal_config.yml'}
 
-    it 'is valid' do
-      expect(subject.errors).to eq(['AppMap auto-configuration is currently not available for non Rails projects'])
+    example do
+      expect(subject).to be_valid
     end
   end
 
@@ -89,7 +91,7 @@ describe AppMap::Service::ConfigAnalyzer do
 
     describe '.is_valid?' do
       it 'guesses paths and returns true ' do
-        expect(subject.valid?).to be_falsey
+        expect(subject.valid?).to be_truthy
       end
     end
 

--- a/test/agent_setup_status_test.rb
+++ b/test/agent_setup_status_test.rb
@@ -13,7 +13,7 @@ class AgentSetupInitTest < Minitest::Test
         config: {
           app: 'AppMap Rubygem',
           present: true,
-          valid: false
+          valid: true
         },
         project: {
           agentVersion: AppMap::VERSION,

--- a/test/agent_setup_validate_test.rb
+++ b/test/agent_setup_validate_test.rb
@@ -20,26 +20,17 @@ class AgentSetupValidateTest < Minitest::Test
     )
     assert_equal(expected, output.strip)
   end
-    
+
   def test_init_when_config_exists
     output = `./exe/appmap-agent-validate`
     assert_equal 0, $CHILD_STATUS.exitstatus
-    check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      }
-    ])
+    assert_equal JSON.pretty_generate([]), output.strip
   end
 
   def test_init_with_non_existing_config_file
     output = `./exe/appmap-agent-validate -c #{NON_EXISTING_CONFIG_FILENAME}`
     assert_equal 0, $CHILD_STATUS.exitstatus
     check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      },
       {
         level: :error,
         filename: NON_EXISTING_CONFIG_FILENAME,
@@ -54,10 +45,6 @@ class AgentSetupValidateTest < Minitest::Test
     check_output(output, [
       {
         level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      },
-      {
-        level: :error,
         filename: INVALID_YAML_CONFIG_FILENAME,
         message: "AppMap configuration #{INVALID_YAML_CONFIG_FILENAME} is not valid YAML",
         detailed_message: "(#{INVALID_YAML_CONFIG_FILENAME}): " \
@@ -70,10 +57,6 @@ class AgentSetupValidateTest < Minitest::Test
     output = `./exe/appmap-agent-validate -c #{INVALID_CONFIG_FILENAME}`
     assert_equal 0, $CHILD_STATUS.exitstatus
     check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      },
       {
         level: :error,
         filename: INVALID_CONFIG_FILENAME,


### PR DESCRIPTION
Fixes #292.

Note this simply reverts #174 — neither that pull request nor the commit provides any rationale for it, but we might want to try to remember it before we merge this. 

One reason that comes to mind might have been because there is no automatic setup for non-rails project (AFAIK); the user has to know to go add `require 'appmap'` to appropriate test environment files (eg. conventionally `spec_helper.rb` for rspec) before AppMap can work. With Rails it just works because Rails environment setup autoloads all the gems from the bundle.