### PR TITLE
Allow non rails projects in validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ Layout/CaseIndentation:
 Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
 
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ rbenv:
 - 3.0
 - 3.1
 
+node_js: lts/*
+
 services:
 - postgresql
-
-before_install:
-  - |
-    nvm install --lts \
-      && nvm use --lts \
-      && npm i -g yarn
 
 before_deploy:
   - |

--- a/lib/appmap/command/agent_setup/validate.rb
+++ b/lib/appmap/command/agent_setup/validate.rb
@@ -14,7 +14,7 @@ module AppMap
           schema = YAML.safe_load(File.read(schema_path))
           result = {
             version: 2,
-            errors: config_validator.valid? ? [] : config_validator.violations.map(&:to_h),
+            errors: config_validator.violations.map(&:to_h),
             schema: schema
           }
           puts JSON.pretty_generate(result)

--- a/lib/appmap/service/config_analyzer.rb
+++ b/lib/appmap/service/config_analyzer.rb
@@ -25,7 +25,11 @@ module AppMap
 
       def errors
         valid?
-        config_validator.violations.map(&:message)
+        config_validator.violations.filter(&:error?).map(&:message)
+      end
+
+      def warnings
+        config_validator.violations.filter(&:warning?).map(&:message)
       end
 
       private

--- a/lib/appmap/service/validator/violation.rb
+++ b/lib/appmap/service/validator/violation.rb
@@ -44,6 +44,14 @@ module AppMap
             hash[var.to_s.delete("@")] = self.instance_variable_get(var)
           end.compact
         end
+
+        def error?
+          @level == :error
+        end
+
+        def warning?
+          @level == :warning
+        end
       end
     end
   end

--- a/spec/service/config_analyzer_spec.rb
+++ b/spec/service/config_analyzer_spec.rb
@@ -22,8 +22,9 @@ describe AppMap::Service::ConfigAnalyzer do
     example do
       expect(subject).to be_present
       expect(subject.app_name).to eq 'appmap'
-      expect(subject.errors).to eq ['AppMap auto-configuration is currently not available for non Rails projects']
-      expect(subject).to_not be_valid
+      expect(subject.errors).to be_empty
+      expect(subject.warnings).to include include 'Rails'
+      expect(subject).to be_valid
     end
   end
 
@@ -31,7 +32,7 @@ describe AppMap::Service::ConfigAnalyzer do
     let(:config_file) { 'spec/fixtures/config/maximal_config.yml' }
 
     example do
-      expect(subject.errors).to eq(['AppMap auto-configuration is currently not available for non Rails projects'])
+      expect(subject).to be_valid
     end
   end
 
@@ -51,7 +52,7 @@ describe AppMap::Service::ConfigAnalyzer do
     example do
       expect(subject).to be_present
       expect(subject.app_name).to eq('app')
-      expect(subject).to_not be_valid
+      expect(subject).to be_valid
     end
   end
 end

--- a/spec/service/config_analyzer_spec.rb
+++ b/spec/service/config_analyzer_spec.rb
@@ -7,96 +7,51 @@ describe AppMap::Service::ConfigAnalyzer do
   subject { described_class.new(config_file) }
 
   context 'with non-existing config' do
-    let(:config_file) { 'spec/fixtures/config/non_existing_config.yml'}
+    let(:config_file) { 'spec/fixtures/config/non_existing_config.yml' }
 
-    describe '.app_name' do
-      it 'returns nil' do
-        expect(subject.app_name).to be_nil
-      end
-    end
-
-    describe '.is_valid?' do
-      it 'returns false' do
-        expect(subject.valid?).to be_falsey
-      end
-    end
-
-    describe '.is_present?' do
-      it 'returns false' do
-        expect(subject.present?).to be_falsey
-      end
+    example do
+      expect(subject).to_not be_valid
+      expect(subject.app_name).to be_nil
+      expect(subject).to_not be_present
     end
   end
 
   context 'with valid but non rails config' do
-    let(:config_file) { 'spec/fixtures/config/valid_config.yml'}
+    let(:config_file) { 'spec/fixtures/config/valid_config.yml' }
 
-    describe '.app_name' do
-      it 'returns app name value from config' do
-        expect(subject.app_name).to eq('appmap')
-      end
-    end
-
-    it 'is valid' do
-      expect(subject.errors).to eq(['AppMap auto-configuration is currently not available for non Rails projects'])
-    end
-
-    describe '.is_present?' do
-      it 'returns true' do
-        expect(subject.present?).to be_truthy
-      end
+    example do
+      expect(subject).to be_present
+      expect(subject.app_name).to eq 'appmap'
+      expect(subject.errors).to eq ['AppMap auto-configuration is currently not available for non Rails projects']
+      expect(subject).to_not be_valid
     end
   end
 
   context 'with maximal valid config' do
-    let(:config_file) { 'spec/fixtures/config/maximal_config.yml'}
+    let(:config_file) { 'spec/fixtures/config/maximal_config.yml' }
 
-    it 'is valid' do
+    example do
       expect(subject.errors).to eq(['AppMap auto-configuration is currently not available for non Rails projects'])
     end
   end
 
   context 'with invalid YAML config' do
-    let(:config_file) { 'spec/fixtures/config/invalid_yaml_config.yml'}
+    let(:config_file) { 'spec/fixtures/config/invalid_yaml_config.yml' }
 
-    describe '.app_name' do
-      it 'returns app name value from config' do
-        expect(subject.app_name).to be_nil
-      end
-    end
-
-    describe '.is_valid?' do
-      it 'returns false' do
-        expect(subject.valid?).to be_falsey
-      end
-    end
-
-    describe '.is_present?' do
-      it 'return true' do
-        expect(subject.present?).to be_truthy
-      end
+    example do
+      expect(subject).to be_present
+      expect(subject.app_name).to be_nil
+      expect(subject).to_not be_valid
     end
   end
 
   context 'with incomplete config' do
-    let(:config_file) { 'spec/fixtures/config/incomplete_config.yml'}
+    let(:config_file) { 'spec/fixtures/config/incomplete_config.yml' }
 
-    describe '.app_name' do
-      it 'returns nil' do
-        expect(subject.app_name).to eq('app')
-      end
-    end
-
-    describe '.is_valid?' do
-      it 'guesses paths and returns true ' do
-        expect(subject.valid?).to be_falsey
-      end
-    end
-
-    describe '.is_present?' do
-      it 'returns true' do
-        expect(subject.present?).to be_truthy
-      end
+    example do
+      expect(subject).to be_present
+      expect(subject.app_name).to eq('app')
+      expect(subject).to_not be_valid
     end
   end
 end

--- a/test/agent_setup_status_test.rb
+++ b/test/agent_setup_status_test.rb
@@ -13,7 +13,7 @@ class AgentSetupInitTest < Minitest::Test
         config: {
           app: 'AppMap Rubygem',
           present: true,
-          valid: false
+          valid: true
         },
         project: {
           agentVersion: AppMap::VERSION,

--- a/test/agent_setup_validate_test.rb
+++ b/test/agent_setup_validate_test.rb
@@ -10,6 +10,13 @@ class AgentSetupValidateTest < Minitest::Test
   INVALID_CONFIG_FILENAME = 'spec/fixtures/config/invalid_config.yml'
   MISSING_PATH_OR_GEM_CONFIG_FILENAME = 'spec/fixtures/config/missing_path_or_gem.yml'
 
+  RAILS_WARNING = {
+    level: :warning,
+    message: "This is not a Rails project. AppMap won't be automatically loaded.",
+    detailed_message: "Please ensure you `require 'appmap'` in your test environment.",
+    help_urls: [ 'https://appmap.io/docs/reference/appmap-ruby#tests-recording' ]
+  }.freeze
+
   def check_output(output, expected_errors)
     expected = JSON.pretty_generate(
       {
@@ -20,26 +27,18 @@ class AgentSetupValidateTest < Minitest::Test
     )
     assert_equal(expected, output.strip)
   end
-    
+
   def test_init_when_config_exists
     output = `./exe/appmap-agent-validate`
     assert_equal 0, $CHILD_STATUS.exitstatus
-    check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      }
-    ])
+    check_output(output, [RAILS_WARNING])
   end
 
   def test_init_with_non_existing_config_file
     output = `./exe/appmap-agent-validate -c #{NON_EXISTING_CONFIG_FILENAME}`
     assert_equal 0, $CHILD_STATUS.exitstatus
     check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      },
+      RAILS_WARNING,
       {
         level: :error,
         filename: NON_EXISTING_CONFIG_FILENAME,
@@ -52,10 +51,7 @@ class AgentSetupValidateTest < Minitest::Test
     output = `./exe/appmap-agent-validate -c #{INVALID_YAML_CONFIG_FILENAME}`
     assert_equal 0, $CHILD_STATUS.exitstatus
     check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      },
+      RAILS_WARNING,
       {
         level: :error,
         filename: INVALID_YAML_CONFIG_FILENAME,
@@ -70,10 +66,7 @@ class AgentSetupValidateTest < Minitest::Test
     output = `./exe/appmap-agent-validate -c #{INVALID_CONFIG_FILENAME}`
     assert_equal 0, $CHILD_STATUS.exitstatus
     check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      },
+      RAILS_WARNING,
       {
         level: :error,
         filename: INVALID_CONFIG_FILENAME,
@@ -87,10 +80,7 @@ class AgentSetupValidateTest < Minitest::Test
     output = `./exe/appmap-agent-validate -c #{MISSING_PATH_OR_GEM_CONFIG_FILENAME}`
     assert_equal 0, $CHILD_STATUS.exitstatus
     check_output(output, [
-      {
-        level: :error,
-        message: 'AppMap auto-configuration is currently not available for non Rails projects'
-      },
+      RAILS_WARNING,
       {
         level: :error,
         filename: MISSING_PATH_OR_GEM_CONFIG_FILENAME,


### PR DESCRIPTION
Non-Rails projects won't autoload AppMap, but this is not a fatal
error. Instead of signaling one show a warning with some details on
how to ensure it's loaded.

Fixes #292
Note https://github.com/getappmap/appmap-js/pull/829 is needed for this to actually work.