### PR TITLE
fix: Use correct signature for Init_appmap() in appmap.c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ rbenv:
 - 3.0
 - 3.1
 
+node_js: lts/*
+
 services:
 - postgresql
-
-before_install:
-  - |
-    nvm install --lts \
-      && nvm use --lts \
-      && npm i -g yarn
 
 before_deploy:
   - |

--- a/ext/appmap/appmap.c
+++ b/ext/appmap/appmap.c
@@ -101,7 +101,7 @@ am_previous_bindings(VALUE self, VALUE level)
   return rb_debug_inspector_open(bindings_callback, (void *) level);
 }
 
-void Init_appmap() {
+void Init_appmap(void) {
   VALUE appmap = rb_define_module("AppMap");
   am_AppMapHook = rb_define_class_under(appmap, "Hook", rb_cObject);
 


### PR DESCRIPTION
`Init_appmap()` is an old (K&R) C signature style which is wrong and causes a warning with `-Wold-style-definition` (and an error with `-Werror`).

Note: this issue has been reported by a user (Mike State on appmap-group.slack.com) and they might be using the fix branch directly, so let's keep it around for a while longer after it's merged.