### PR TITLE
fix: Don't match ending ) in swaggerize_path

### DIFF
--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -152,7 +152,8 @@ module AppMap
         path = path.split('(.')[0]
         tokens = path.split('/')
         tokens.map do |token|
-          token.gsub(/^:(.*)/, '{\1}')
+          # stop matching if an ending ) is found
+          token.gsub(/^:(.*[^\)])/, '{\1}')
         end.join('/')
       end
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -34,5 +34,9 @@ describe AppMap::Util do
     it 'ignores already swaggerized paths' do
       expect(AppMap::Util.swaggerize_path('/org/{org_id}')).to eq('/org/{org_id}')
     end
+
+    it 'ignores ending ) to not create malformed ({)} paths' do
+      expect(AppMap::Util.swaggerize_path('(/locale/:locale)/api/users/:id(.:format)')).to eq('(/locale/{locale})/api/users/{id}')
+    end
   end
 end


### PR DESCRIPTION
[Forem](https://github.com/forem/forem) was passing to `swaggerize_path` the input
```
(/locale/:locale)/api/users/:id(.:format)
```
returning the output
```
(/locale/{locale)}/api/users/{id}
```
The`)` should have not been inside `{}`.

This pr fixes this.