### PR TITLE
fix: Fix bug with rswag's `run_test!`

### DIFF
--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -238,7 +238,7 @@ if AppMap::RSpec.enabled?
             proc do
               AppMap::RSpec.begin_spec example
               begin
-                instance_exec(&fn)
+                instance_exec(example, &fn)
               ensure
                 AppMap::RSpec.end_spec example, exception: $!
               end

--- a/spec/fixtures/rails6_users_app/Gemfile
+++ b/spec/fixtures/rails6_users_app/Gemfile
@@ -15,6 +15,7 @@ group :development, :test do
   gem 'appmap', path: '../../..'
   gem 'cucumber-rails', require: false
   gem 'rspec-rails'
+  gem "rswag-specs", "~> 2.8.0" # RSwag - Swagger-based DSL for rspec & accompanying rake task for generating Swagger files
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
 end

--- a/spec/fixtures/rails6_users_app/spec/requests/rswag_spec.rb
+++ b/spec/fixtures/rails6_users_app/spec/requests/rswag_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require 'rack/test'
+require "swagger_helper"
+
+# rubocop:disable RSpec/EmptyExampleGroup
+
+RSpec.describe Api::UsersController, type: :request do
+  describe 'POST /api/users' do
+    path "/api/users" do
+      post "new user" do
+
+        describe 'with rswag' do
+          # demonstrate bug with Rswag::Specs::ExampleGroupHelpers::run_test!
+          #
+          # NoMethodError:
+          #   undefined method `metadata' for nil:NilClass
+          #
+          # /home/test/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rswag-specs-2.8.0/lib/rswag/specs/example_group_helpers.rb:135:in `block in run_test!'
+          # /home/test/src/appmap-ruby/lib/appmap/rspec.rb:241:in `instance_exec'
+          response "422", "Unprocessable entity" do
+            run_test!
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/fixtures/rails6_users_app/spec/swagger_helper.rb
+++ b/spec/fixtures/rails6_users_app/spec/swagger_helper.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you"re using the rswag-api to serve API descriptions, you"ll need
+  # to ensure that it"s configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join("swagger").to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the "rswag:specs:swaggerize" rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe "...", swagger_doc: "v2/swagger.json"
+  config.swagger_docs = {
+    "v1/api_v1.json" => {
+      openapi: "1.0",
+      info: {
+        title: "Rails 6 Users App API V1",
+        version: "1.0.0",
+        description: "Access resources via API."
+      },
+      paths: {},
+      servers: [
+        {
+          url: "http://127.0.0.1/",
+          description: "Development server"
+        },
+      ],
+      security: [],
+      components: {
+        securitySchemes: {
+          "api-key": {
+            type: :apiKey,
+            name: "api-key",
+            in: :header,
+            description: "API Key authentication.
+
+Authentication for some endpoints."
+          }
+        },
+        parameters: {
+          pageParam: {
+            in: :query,
+            name: :page,
+            required: false,
+            description: "Pagination page",
+            schema: {
+              type: :integer,
+              format: :int32,
+              minimum: 1,
+              default: 1
+            }
+          },
+          perPageParam10to1000: {
+            in: :query,
+            name: :per_page,
+            required: false,
+            description: "Page size (the number of items to return per page). \
+The default maximum value can be overridden by \"API_PER_PAGE_MAX\" environment variable.",
+            schema: {
+              type: :integer,
+              format: :int32,
+              minimum: 1,
+              maximum: 1000,
+              default: 10
+            }
+          },
+        },
+        schemas: {}
+      }
+    }
+  }
+
+  # Specify the format of the output Swagger file when running "rswag:specs:swaggerize".
+  # Defaults to json. Accepts ":json" and ":yaml".
+  config.swagger_format = :json
+end

--- a/spec/service/integration_test_path_finder_spec.rb
+++ b/spec/service/integration_test_path_finder_spec.rb
@@ -8,14 +8,14 @@ describe AppMap::Service::IntegrationTestPathFinder do
 
   describe '.count' do
     it 'counts existing paths' do
-      expect(subject.count_paths).to be(3)
+      expect(subject.count_paths).to be(4)
     end
   end
 
   describe '.find' do
     it 'finds paths' do
       expect(subject.find).to eq({
-        rspec: %w[spec/controllers],
+        rspec: %w[spec/controllers spec/requests],
         minitest: %w[test/controllers test/integration],
         cucumber: []
       })

--- a/test/agent_setup_status_test.rb
+++ b/test/agent_setup_status_test.rb
@@ -35,7 +35,7 @@ class AgentSetupInitTest < Minitest::Test
           framework: :rspec,
           command: {
             program: 'bundle',
-            args: %w[exec rspec ./spec/controllers],
+            args: %w[exec rspec ./spec/controllers ./spec/requests],
             environment: { }
           }
         },


### PR DESCRIPTION
When running rswag tests, pass the `RSpec::Core::Example` object to rswag's [`run_test!`](https://github.com/rswag/rswag/blob/master/rswag-specs/lib/rswag/specs/example_group_helpers.rb#L118).

`RSpec::Core::Example` wasn't being passed. AppMap wasn't crashing so far because example wasn't being used with with `RSPEC_VERSION < 3`. When used with rspec version 3+ this bug started to occur.

Added testcase `spec/fixtures/rails6_users_app/spec/requests/rswag_spec.rb` and adjusted existing testcases to account for it.

After this change, verified Forem's `./spec/requests/api/v1` tests all pass without the exclusion pattern used before for `./spec/requests/api/v1/docs/*_spec.rb`
![forem_api_v1_tests_pass_with_appmap](https://user-images.githubusercontent.com/111290954/214951502-a2b5689f-33aa-4e72-a0ee-93f7a3853aea.png)


Fixes https://github.com/getappmap/appmap-ruby/issues/309