### PR TITLE
feat: Support Ruby 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
 - 2.7.6
 - 3.0.1 # doesn't show in pre-installed list
 - 3.1.2
+- 3.2.0
 
 addons:
   postgresql: "13"

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -357,7 +357,7 @@ module AppMap
             unless config_present
               warn Util.color(YAML.dump(config_yaml), :magenta)
               dirname = Pathname.new(config_file_name).dirname.expand_path
-              if Dir.exists?(dirname) && File.writable?(dirname)
+              if Dir.exist?(dirname) && File.writable?(dirname)
                 warn Util.color(<<~CONFIG_FILE_MSG, :magenta)
                 This file will be saved to #{Pathname.new(config_file_name).expand_path},
                 where you can customize it.

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -7,7 +7,7 @@ module AppMap
 
   APPMAP_FORMAT_VERSION = '1.10.0'
 
-  SUPPORTED_RUBY_VERSIONS = %w[2.5 2.6 2.7 3.0 3.1].freeze
+  SUPPORTED_RUBY_VERSIONS = %w[2.5 2.6 2.7 3.0 3.1 3.2].freeze
 
   DEFAULT_APPMAP_DIR = 'tmp/appmap'.freeze
   DEFAULT_CONFIG_FILE_PATH = 'appmap.yml'.freeze

--- a/spec/fixtures/hook/anonargs_passed.rb
+++ b/spec/fixtures/hook/anonargs_passed.rb
@@ -1,0 +1,31 @@
+# Since ruby 3.2, anonymous rest arguments can be passed as arguments,
+# instead of just used in method parameters.
+class AnonArgsPassed
+  class << self
+    def anon_rest(*)
+      'anon'
+    end
+
+    def has_anon_rest_calls_anon_rest(*)
+      anon_rest(*)
+    end
+
+
+    def non_anon_rest_first(*, arg1, arg2)
+      [arg1, arg2]
+    end
+
+    def has_anon_rest_calls_non_anon_rest_first(*)
+      non_anon_rest_first(*)
+    end
+
+
+    def non_anon_rest_last(arg1, arg2, *)
+      [arg1, arg2]
+    end
+
+    def has_anon_rest_calls_non_anon_rest_last(*)
+      non_anon_rest_last(*)
+    end
+  end
+end

--- a/spec/fixtures/hook/anonkwargs_passed.rb
+++ b/spec/fixtures/hook/anonkwargs_passed.rb
@@ -1,0 +1,24 @@
+# Since ruby 3.2, anonymous keyword rest arguments can be passed as
+# arguments, instead of just used in method parameters.
+class AnonKwargsPassed
+  class << self
+    def kw_rest(**)
+      'kwargs'
+    end
+
+    def has_kw_rest_calls_kw_rest(args, **)
+      kw_rest(**)
+    end
+
+    # there's no has_kw_rest_calls_kw_rest_first because by convention
+    # keyword arguments are always last
+
+    def kw_rest_last(args)
+      args
+    end
+
+    def has_kw_rest_calls_kw_rest_last(*args, **)
+      kw_rest_last(**)
+    end
+  end
+end

--- a/spec/fixtures/hook/args_to_kwargs.rb
+++ b/spec/fixtures/hook/args_to_kwargs.rb
@@ -1,0 +1,15 @@
+# Since ruby 3.2, all methods wishing to delegate keyword arguments
+# through *args must now be marked with ruby2_keywords, with no
+# exception.
+class ArgsToKwArgs
+  class << self
+    def kw_rest(**kwargs)
+      kwargs
+    end
+
+    # if ruby2_keywords is removed this test fails
+    ruby2_keywords def has_args_calls_kwargs(*args)
+      kw_rest(*args)
+    end
+  end
+end

--- a/spec/fixtures/hook/proc_no_autosplat.rb
+++ b/spec/fixtures/hook/proc_no_autosplat.rb
@@ -1,0 +1,9 @@
+# Since ruby 3.2, a proc that accepts a single positional argument and
+# keywords will no longer autosplat.
+class ProcNoAutosplat
+  class << self
+    def proc_no_autosplat(params)
+      proc{|a, **k| a}.call(params)
+    end
+  end
+end

--- a/spec/request_recording_spec.rb
+++ b/spec/request_recording_spec.rb
@@ -30,7 +30,7 @@ describe 'request recording', :order => :defined do
     expect(res).to be_a(Net::HTTPOK)
     expect(res).to include('appmap-file-name')
     appmap_file_name = res['AppMap-File-Name']
-    expect(File.exists?(appmap_file_name)).to be(true)
+    expect(File.exist?(appmap_file_name)).to be(true)
     appmap = JSON.parse(File.read(appmap_file_name))
     # Every event should come from the same thread
     expect(appmap['events'].map {|evt| evt['thread_id']}.uniq.length).to eq(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,12 @@ def ruby_2?
   RUBY_VERSION.split('.')[0].to_i == 2
 end
 
+def ruby_3_2_or_higher?
+  version = RUBY_VERSION.split('.')
+  ((version[0].to_i == 3 && version[1].to_i >= 2) or
+   version[0].to_i >= 4)
+end
+
 shared_context 'collect events' do
   def collect_events(tracer)
     [].tap do |events|


### PR DESCRIPTION
- Add Ruby 3.2 to the test matrix on CI.
- Remove from existing tests use of `Dir.exists?` and `File.exists?` which is deprecated in Ruby 3.2.
- Add four new tests that verify the agent works with the following three changes in Ruby 3.2
 https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/ 

```
Anonymous rest and keyword rest arguments can now be passed as arguments, instead of
just used in method parameters. 
```

```
Methods taking a rest parameter (like *args) and wishing to delegate keyword arguments
through foo(*args) must now be marked with ruby2_keywords (if not already the case). In
other words, all methods wishing to delegate keyword arguments through *args must now
be marked with ruby2_keywords, with no exception. 
```

```
A proc that accepts a single positional argument and keywords will no longer autosplat.
```
- Accept running the agent on Ruby 3.2.

Fixes https://github.com/getappmap/appmap-ruby/issues/312