### PR TITLE
feat: Implement `items` Parameter object format (AppMap v1.10.0)

### DIFF
--- a/lib/appmap/value_inspector.rb
+++ b/lib/appmap/value_inspector.rb
@@ -3,6 +3,7 @@ module AppMap
     extend self
 
     MAX_DEPTH = 3
+    MAX_ARRAY_ELEMENTS = 5
 
     def detect_size(value)
       # Don't risk calling #size on things like data-access objects, which can and will issue queries for this information.
@@ -11,10 +12,17 @@ module AppMap
       end
     end
 
-    def detect_schema(value, max_depth: MAX_DEPTH, type_info: {}, observed_values: Set.new(), depth: 0)
-      return type_info if depth == max_depth
+    def detect_schema(
+      value,
+      max_depth: MAX_DEPTH,
+      max_array_elements: MAX_ARRAY_ELEMENTS,
+      type_info: { class: best_class_name(value) },
+      observed_values: Set.new,
+      depth: 0
+    )
+      return type_info if depth >= max_depth && !array_like?(value)
 
-      if value.respond_to?(:keys)
+      if hash_like?(value)
         return if observed_values.include?(value.object_id)
 
         observed_values << value.object_id
@@ -23,17 +31,22 @@ module AppMap
           next_value = value[key]
 
           value_schema = begin
-              { name: key, class: best_class_name(next_value) }
-            rescue
-              warn "Error in add_schema(#{next_value.class})", $!
-              raise
-            end
+            { name: key, class: best_class_name(next_value) }
+          rescue
+            warn "Error in add_schema(#{next_value.class})", $!
+            raise
+          end
 
           detect_schema(next_value, **{ max_depth: max_depth, type_info: value_schema, observed_values: observed_values, depth: depth + 1 })
         end.compact
         type_info[:properties] = properties unless properties.empty?
-      elsif value.respond_to?(:first)
-        detect_schema(value.first, **{ max_depth: max_depth, type_info: type_info, observed_values: observed_values, depth: depth + 1 })
+      elsif array_like?(value)
+        type_info[:items] = value.take(max_array_elements).map do |next_value|
+          value_schema = { class: best_class_name(next_value) }
+          detect_schema(next_value, **{ max_depth: max_depth, type_info: value_schema, observed_values: observed_values, depth: depth + 1 })
+        end
+
+        type_info[:items] = type_info[:items].compact.uniq(&:hash)
       end
       type_info
     end
@@ -45,6 +58,16 @@ module AppMap
         value_cls = value_cls.superclass
       end
       value_cls&.name || "unknown"
+    end
+
+    private
+
+    def array_like?(value)
+      value.is_a?(Enumerable) && !hash_like?(value)
+    end
+
+    def hash_like?(value)
+      value.respond_to?(:keys)
     end
   end
 end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -60,12 +60,24 @@ describe 'Schema example' do
   describe 'Array of Hashes' do
     let(:value) { [ { id: 1, contents: 'some text' }, { id: 2 } ] }
     it 'is an array containing the schema' do
-      expect(schema).to match(hash_including(
-          properties: [ 
-            { name: :id, class: 'Integer' },
-            { name: :contents, class: 'String' }
+      expect(schema).to match(
+        hash_including(
+          class: 'Array',
+          items: [
+            {
+              class: 'Hash',
+              properties: [
+                { name: :id, class: 'Integer' },
+                { name: :contents, class: 'String' }
+              ]
+            },
+            {
+              class: 'Hash',
+              properties: [ { name: :id, class: 'Integer' } ]
+            }
           ]
-        ))
+        )
+      )
     end
   end
 end


### PR DESCRIPTION
`items` must be captured for array-like data structures to describe the schema of the data held within. Previously array elements were assumed to be objects.

This means we should now be able to write proper schema for the following examples.

### Example 1
Given the following JSON response:
```json
[ "This", "is", "my", "array"]
```

The following properties would be made available in AppMap data:
```json
"return_value": {
  "class": "Array",
  "items": [ "class": "String" ]
 }
```

And can be translated to an OpenAPI compliant definition:
```yml
/api/example:
  get:
    responses:
      '200':
        content:
          application/json:
            schema:
              type: array
              items:
                type: string
```

### Example 2
Given the following JSON response:
```
{
  "keys": ["one", "two", "three"]
}
```

The following properties would be made available in AppMap data:
```json
"return_value": {
  "class": "Hash",
  "properties":  [ 
    {
      "name": "keys",
      "class": "Array",
      "items": [ { "class": "string" } ]
    }
  ]
}
```

And can be translated to an OpenAPI compliant definition:
```yml
/api/example:
  get:
    responses:
      '200':
        content:
          application/json:
            schema:
              type: object
              properties:
                keys: 
                  type: array
                  items:
                    type: string
```