### PR TITLE
fix: backtrace_locations may be nil

### DIFF
--- a/lib/appmap/minitest.rb
+++ b/lib/appmap/minitest.rb
@@ -38,14 +38,7 @@ module AppMap
         if failed
           failure_exception = failures.first || exception
           warn "Failure exception: #{failure_exception}" if AppMap::Minitest::LOG
-
-          first_location = failure_exception.backtrace_locations.find { |location| !Pathname.new(Util.normalize_path(location.absolute_path)).absolute? }
-          failure_location = [ Util.normalize_path(first_location.path), first_location.lineno ].join(':') if first_location
-
-          test_failure = {
-            message: failure_exception.message,
-            location: failure_location,
-          }
+          test_failure = Util.extract_test_failure(failure_exception)
         end
 
         events = []

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -104,14 +104,7 @@ module AppMap
         if failed
           failure_exception = failure || exception
           warn "Failure exception: #{failure_exception}" if AppMap::RSpec::LOG
-
-          first_location = failure_exception.backtrace_locations.find { |location| !Pathname.new(Util.normalize_path(location.absolute_path)).absolute? }
-          failure_location = [ Util.normalize_path(first_location.path), first_location.lineno ].join(':') if first_location
-
-          test_failure = {
-            message: failure_exception.message.strip,
-            location: failure_location,
-          }
+          test_failure = Util.extract_test_failure(failure_exception)
         end
 
         events = []

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -157,6 +157,15 @@ module AppMap
         }
       end
 
+      def extract_test_failure(exception)
+        return unless exception
+
+        { message: exception.message }.tap do |test_failure|
+          first_location = exception.backtrace_locations&.find { |location| !Pathname.new(normalize_path(location.absolute_path)).absolute? }
+          test_failure[:location] = [ normalize_path(first_location.path), first_location.lineno ].join(':') if first_location
+        end
+      end
+
       # Convert a Rails-style path from /org/:org_id(.:format)
       # to Swagger-style paths like /org/{org_id}
       def swaggerize_path(path)

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_helper'
 require 'appmap/util'
 
+def first
+  second
+end
+
+def second
+  raise 'second'
+end
+
 describe AppMap::Util do
   describe 'scenario_filename' do
     let(:subject) { AppMap::Util.method(:scenario_filename) }
@@ -37,6 +45,20 @@ describe AppMap::Util do
 
     it 'ignores ending ) to not create malformed ({)} paths' do
       expect(AppMap::Util.swaggerize_path('(/locale/:locale)/api/users/:id(.:format)')).to eq('(/locale/{locale})/api/users/{id}')
+    end
+  end
+  describe :extract_test_failure do
+    it 'extracts message and location' do
+      begin
+        first
+      rescue
+        exception = $!
+      end
+      expect(exception).to be
+      expect(AppMap::Util.extract_test_failure(exception)).to eq({ message: 'second', location: 'spec/util_spec.rb:11' })
+    end
+    it "ignores location if it's missing" do
+      expect(AppMap::Util.extract_test_failure(Exception.new('test'))).to eq({ message: 'test' })
     end
   end
 end

--- a/test/minitest_test.rb
+++ b/test/minitest_test.rb
@@ -45,7 +45,7 @@ class MinitestTest < Minitest::Test
       metadata = appmap['metadata']
       assert_equal 'failed', metadata['test_status']
       test_failure = metadata['test_failure']
-      assert_equal test_failure['message'], <<~MESSAGE.strip
+      assert_equal test_failure['message'].strip, <<~MESSAGE.strip
       Expected: \"Bye!\"\n  Actual: \"Hello!\"
       MESSAGE
       assert_equal test_failure['location'], 'test/hello_failed_test.rb:10'

--- a/test/rspec_test.rb
+++ b/test/rspec_test.rb
@@ -69,7 +69,7 @@ class RSpecTest < Minitest::Test
       assert_includes appmap.keys, 'metadata'
       metadata = appmap['metadata']
       test_failure = metadata['test_failure']
-      assert_equal test_failure['message'], <<~MESSAGE.strip
+      assert_equal test_failure['message'].strip, <<~MESSAGE.strip
       expected: \"Hello\"\n     got: \"Hello!\"\n\n(compared using ==)
       MESSAGE
       assert_equal test_failure['location'], 'spec/failed_spec.rb:7'


### PR DESCRIPTION
`backtrace_locations` says:

> Returns any backtrace associated with the exception

So, I guess it may be nil.

Fixes #324