### PR TITLE
Hook Rack in Rails

### DIFF
--- a/lib/appmap/handler/rails/context.rb
+++ b/lib/appmap/handler/rails/context.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'appmap/handler'
+
+module AppMap
+  module Handler
+    module Rails
+      # Context of a rails request tracking.
+      # Mostly a utility class to clean up and deduplicate request handler code.
+      class Context
+        def initialize(environment = nil)
+          environment[REQUEST_CONTEXT] = self if environment
+          @thread = Thread.current
+        end
+
+        def self.from(environment)
+          environment[REQUEST_CONTEXT]
+        end
+
+        def self.create(environment)
+          return if from environment
+
+          new environment
+        end
+
+        def self.remove(env)
+          env[REQUEST_CONTEXT] = nil
+        end
+
+        def find_template_render_value
+          @thread[TEMPLATE_RENDER_VALUE].tap do
+            @thread[TEMPLATE_RENDER_VALUE] = nil
+          end
+        end
+
+        # context is set on the rack environment to make sure a single request is only recorded once
+        # even if ActionDispatch::Executor is entered more than once (as can happen with engines)
+        REQUEST_CONTEXT = 'appmap.handler.request.context'
+      end
+    end
+  end
+end

--- a/lib/appmap/railtie.rb
+++ b/lib/appmap/railtie.rb
@@ -32,6 +32,8 @@ module AppMap
           AppMap::Handler::Rails::RequestHandler::RequestListener.method(:begin_request)
         )
       end
+
+      AppMap::Handler::Rails::RequestHandler::RackHook.new.activate
     end
   end
 end if AppMap.recording_enabled?

--- a/spec/fixtures/rails7_users_app/Gemfile
+++ b/spec/fixtures/rails7_users_app/Gemfile
@@ -28,3 +28,5 @@ group :development, :test do
   gem 'pry-byebug', '>=0', '< 99'
   gem 'rspec-rails'
 end
+
+gem 'capybara', '~> 3.39', group: :test

--- a/spec/fixtures/rails7_users_app/config/application.rb
+++ b/spec/fixtures/rails7_users_app/config/application.rb
@@ -10,6 +10,8 @@ require "action_controller/railtie"
 require "action_view/railtie"
 require "rails/test_unit/railtie"
 
+require_relative '../lib/hijacker'
+
 case orm_module
 when 'sequel'
   require 'sequel-rails'
@@ -41,5 +43,6 @@ module App
 
     Rails.autoloaders.main.ignore << File.join(Rails.root, 'app/models')
     config.autoload_paths << File.join(Rails.root, "app/models/#{orm_module}")
+    config.middleware.insert_before(-1, Hijacker)
   end
 end

--- a/spec/fixtures/rails7_users_app/lib/hijacker.rb
+++ b/spec/fixtures/rails7_users_app/lib/hijacker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Rack middleware that changes the response
+# code to 422 if the query string is "hi"
+class Hijacker
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env).tap do |response|
+      response[0] = 422 if env['QUERY_STRING'] == 'hi'
+    end
+  end
+end

--- a/spec/fixtures/rails7_users_app/spec/system/rack_hijacking_spec.rb
+++ b/spec/fixtures/rails7_users_app/spec/system/rack_hijacking_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Rack response hijacking', type: :system do
+  before do
+    driven_by :rack_test
+  end
+
+  it 'changes the response on the index to 422' do
+    visit '/users?hi'
+    expect(page.status_code).to equal 422
+  end
+end

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -250,6 +250,24 @@ describe 'Rails' do
         end
       end
     end
+
+    next unless rails_version == 7
+
+    describe 'with middleware' do
+      let(:appmap_json_file) do
+        'Rack_response_hijacking_changes_the_response_on_the_index_to_422.appmap.json'
+      end
+
+      it 'records the middleware effects' do
+        expect(events).to include(
+          hash_including(
+            'http_server_response' => hash_including(
+              'status_code' => 422
+            )
+          )
+        )
+      end
+    end
   end
 
   describe 'with default appmap.yml' do

--- a/spec/rails_spec_helper.rb
+++ b/spec/rails_spec_helper.rb
@@ -87,8 +87,7 @@ class TestRailsApp
 
     prepare_db
     FileUtils.rm_rf tmpdir
-    run_cmd \
-      './bin/rspec spec/controllers/users_controller_spec.rb spec/controllers/users_controller_api_spec.rb'
+    run_cmd './bin/rspec'
     @specs_ran = true
   end
 


### PR DESCRIPTION
Hook requests in Rails on the Rack level in addition to ActionController. This allows intercepting any changes and responses made by the middleware. We're still hooking ActionController, because controller tests don't use Rack, but the ActionController hook is skipped if the rack hook has been activated on the request.

Fixes #323 (I believe)
