### PR TITLE
fix: Handle KeyError in signature lookup

### DIFF
--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -499,6 +499,11 @@ module AppMap
     end
 
     def never_hook?(cls, method)
+      unless method
+        HookLog.log "method is nil" if HookLog.enabled?
+        return true
+      end
+
       _, separator, = ::AppMap::Hook.qualify_method_name(method)
       if exclude.member?(cls.name) || exclude.member?([ cls.name, separator, method.name ].join)
         HookLog.log "Hooking of #{method} disabled by configuration" if HookLog.enabled?

--- a/spec/method_hash_key_spec.rb
+++ b/spec/method_hash_key_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'appmap/hook/method'
+
+describe 'method_hash_key' do
+  describe 'of a normal method' do
+    it 'is a hash' do
+      expect(AppMap::Hook.method_hash_key(AppMap::Hook, AppMap::Hook.method(:method_hash_key))).to be_a Integer
+    end
+  end
+  describe 'when the class hash raises an error' do
+    it 'is nil' do
+      cls = Class.new do
+        def say_hello; 'hello'; end
+
+        class << self
+          def hash
+            raise TypeError, 'raise the type error needed by the test'
+          end
+        end
+      end
+
+      expect { cls.hash }.to raise_error(TypeError, 'raise the type error needed by the test')
+      expect(AppMap::Hook.method_hash_key(cls, cls.new.method(:say_hello))).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Encountered while mapping forem:

```
An error occurred while loading ./spec/models/reaction_category_spec.rb.
Failure/Error: end

TypeError:
  no implicit conversion of Hash into Integer
WARNING: Shared example group 'Taggable' has been previously defined at:
  /home/runner/work/forem/forem/spec/models/shared_examples/taggable_spec.rb:1
...and you are now defining it at:
  /home/runner/work/forem/forem/spec/models/shared_examples/taggable_spec.rb:1
The new definition will overwrite the original one.
```