### PR TITLE
Prevent environment mangling on Rails route resolution

### DIFF
--- a/lib/appmap/handler/rails/request_handler.rb
+++ b/lib/appmap/handler/rails/request_handler.rb
@@ -58,6 +58,8 @@ module AppMap
           private
 
           def normalized_path(request, router = ::Rails.application.routes.router)
+            # use a cloned environment because the router can modify it
+            request = ActionDispatch::Request.new request.env.clone
             router.recognize request do |route, _|
               app = route.app
               next unless app.matches? request

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -161,7 +161,9 @@ module AppMap
         return unless exception
 
         { message: exception.message }.tap do |test_failure|
-          first_location = exception.backtrace_locations&.find { |location| !Pathname.new(normalize_path(location.absolute_path)).absolute? }
+          first_location = exception.backtrace_locations&.find do |location|
+            !Pathname.new(normalize_path(location.absolute_path || location.path)).absolute?
+          end
           test_failure[:location] = [ normalize_path(first_location.path), first_location.lineno ].join(':') if first_location
         end
       end

--- a/spec/fixtures/rails7_users_app/Gemfile
+++ b/spec/fixtures/rails7_users_app/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 
 gem "rails", "~> 7.0.2", ">= 7.0.2.3"
+gem 'sprockets-rails'
 gem 'haml-rails'
 gem "pg", "~> 1.1"
 gem 'activerecord', require: false

--- a/spec/fixtures/rails7_users_app/spec/system/rack_spec.rb
+++ b/spec/fixtures/rails7_users_app/spec/system/rack_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Rack response hijacking', type: :system do
+RSpec.describe 'Rack stack', type: :system do
   before do
     driven_by :rack_test
   end
@@ -10,5 +10,10 @@ RSpec.describe 'Rack response hijacking', type: :system do
   it 'changes the response on the index to 422' do
     visit '/users?hi'
     expect(page.status_code).to equal 422
+  end
+
+  it 'can serve sprocket assets' do
+    visit '/assets/application.css'
+    expect(page.status_code).to equal 200
   end
 end

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -255,7 +255,7 @@ describe 'Rails' do
 
     describe 'with middleware' do
       let(:appmap_json_file) do
-        'Rack_response_hijacking_changes_the_response_on_the_index_to_422.appmap.json'
+        'Rack_stack_changes_the_response_on_the_index_to_422.appmap.json'
       end
 
       it 'records the middleware effects' do
@@ -263,6 +263,25 @@ describe 'Rails' do
           hash_including(
             'http_server_response' => hash_including(
               'status_code' => 422
+            )
+          )
+        )
+      end
+    end
+
+    describe 'with sprockets' do
+      let(:appmap_json_file) do
+        'Rack_stack_can_serve_sprocket_assets.appmap.json'
+      end
+
+      it 'records the middleware effects' do
+        expect(events).to include(
+          hash_including(
+            'http_server_response' => hash_including(
+              'status_code' => 200,
+              'headers' => hash_including(
+                'content-type' => 'text/css; charset=utf-8'
+              )
             )
           )
         )

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -60,5 +60,17 @@ describe AppMap::Util do
     it "ignores location if it's missing" do
       expect(AppMap::Util.extract_test_failure(Exception.new('test'))).to eq({ message: 'test' })
     end
+
+    class_eval(<<-CLASS_EVAL, __FILE__, __LINE__ + 1)
+      def class_evaled
+        raise 'hell'
+      end
+    CLASS_EVAL
+
+    it 'can extract location even for eval-declared functions' do
+      class_evaled
+    rescue StandardError => e
+      expect(AppMap::Util.extract_test_failure(e)).to eq({ message: 'hell', location: 'spec/util_spec.rb:66' })
+    end
   end
 end


### PR DESCRIPTION
When an HTTP route goes to a rails engine, the router modifies the environment before passing it downstream. Since we're using the router to resolve the normalized path, in this case the environment could have been modified before rails stack actually got to see it, preventing it from routing the request correctly. This is what caused #329 

Using a clone of the environment to match the route prevents this problem, ensuring Rails stack gets an unmodified environment to do its own routing on it again.

This PR also fixes another problem I've found while trying to fix this.