### PR TITLE
feat: Add `appmap-agent-config` command to bootstrap appmap.yml

### DIFF
--- a/exe/appmap-agent-config
+++ b/exe/appmap-agent-config
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require 'appmap'
+require 'appmap/command/agent_setup/config'
+
+@options = { config_file: AppMap::DEFAULT_CONFIG_FILE_PATH, force: false }
+
+OptionParser.new do |parser|
+  parser.banner = 'Usage: appmap-agent-config [options]'
+
+  description = "AppMap configuration file path (default: #{AppMap::DEFAULT_CONFIG_FILE_PATH})"
+  parser.on('-c', '--config=FILEPATH', description) do |filepath|
+    @options[:config_file] = filepath
+  end
+
+  parser.on('-f', '--force', 'Overwrite existing configuration file') do
+    @options[:force] = true
+  end
+end.parse!
+
+begin
+  AppMap::Command::AgentSetup::Config.new(@options[:config_file], @options[:force]).perform
+
+  puts "AppMap configuration file created at #{@options[:config_file]}"
+rescue AppMap::Command::AgentSetup::Config::FileExistsError
+  puts "AppMap configuration file already exists at #{@options[:config_file]}"
+  puts 'Use the --force option to overwrite.'
+  exit 1
+end

--- a/lib/appmap/command/agent_setup/config.rb
+++ b/lib/appmap/command/agent_setup/config.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'appmap/service/guesser'
+
+module AppMap
+  module Command
+    module AgentSetup
+      ConfigStruct = Struct.new(:config_file, :overwrite)
+
+      class Config < ConfigStruct
+        class FileExistsError < StandardError; end
+
+        def perform
+          raise FileExistsError unless overwrite || !File.exist?(config_file)
+
+          config = {
+            'name' => Service::Guesser.guess_name,
+            'packages' => Service::Guesser.guess_paths.map { |path| { 'path' => path } },
+            'language' => 'ruby',
+            'appmap_dir' => 'tmp/appmap'
+          }
+
+          File.write(config_file, YAML.dump(config))
+        end
+      end
+    end
+  end
+end

--- a/test/agent_setup_config_test.rb
+++ b/test/agent_setup_config_test.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AgentSetupConfigTest < Minitest::Spec
+  CONFIG_FILENAME = '123.yml'
+
+  before do
+    @exe_path = File.expand_path(File.join('..', 'exe', 'appmap-agent-config'), __dir__)
+    @dir = Dir.mktmpdir('appmap-config-test')
+    @cwd = Dir.pwd
+    @expected_config = <<~YAML
+    ---
+    name: #{File.basename(@dir)}
+    packages: []
+    language: ruby
+    appmap_dir: tmp/appmap
+    YAML
+
+    Dir.chdir(@dir)
+  end
+
+  after do
+    FileUtils.rm_f(@dir)
+    Dir.chdir(@cwd)
+  end
+
+  def test_config_creation
+    output = `#{@exe_path}`
+
+    assert_match(/configuration file created/, output)
+    assert_equal(0, $CHILD_STATUS.exitstatus)
+    assert_equal(@expected_config, File.read('appmap.yml'))
+  end
+
+  def test_config_with_custom_filename
+    output = `#{@exe_path} -c #{CONFIG_FILENAME}`
+
+    assert_match(/configuration file created/, output)
+    assert_equal(0, $CHILD_STATUS.exitstatus)
+    assert_equal(@expected_config, File.read(CONFIG_FILENAME))
+  end
+
+  def test_config_creation_with_existing_config
+    File.write(CONFIG_FILENAME, 'foo')
+
+    output = `#{@exe_path} -c #{CONFIG_FILENAME}`.strip!
+
+    assert_match(/configuration file already exists/, output)
+    assert_equal(1, $CHILD_STATUS.exitstatus)
+    assert_equal('foo', File.read(CONFIG_FILENAME))
+  end
+
+  def test_config_creation_with_force_overwrites_existing_config
+    File.write(CONFIG_FILENAME, 'foo')
+
+    output = `#{@exe_path} -f`
+
+    assert_match(/configuration file created/, output)
+    assert_equal(0, $CHILD_STATUS.exitstatus)
+    assert_equal(@expected_config, File.read('appmap.yml'))
+  end
+end


### PR DESCRIPTION
This command will be used during the AppMap manual install process to initialize an `appmap.yml`. 