### PR TITLE
feat: Record rswag

### DIFF
--- a/lib/appmap/agent.rb
+++ b/lib/appmap/agent.rb
@@ -73,6 +73,7 @@ module AppMap
     # and returns an AppMap as a Hash.
     def record
       tracer = tracing.trace
+      tracer.enable
       begin
         yield
       ensure

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -68,7 +68,7 @@ module AppMap
             example_group.parent_groups.first
           end
 
-        example_group_parent != example_group ? ScopeExampleGroup.new(example_group_parent) : nil
+        example_group_parent == example_group ? nil : ScopeExampleGroup.new(example_group_parent)
       end
     end
 
@@ -87,7 +87,7 @@ module AppMap
 
         warn "Starting recording of example #{example}@#{source_location}" if AppMap::RSpec::LOG
         @trace = AppMap.tracing.trace
-        @webdriver_port = webdriver_port.()
+        @webdriver_port = webdriver_port.call
       end
 
       def source_location
@@ -182,7 +182,7 @@ module AppMap
       end
 
       def config
-        @config or raise "AppMap is not configured"
+        @config or raise 'AppMap is not configured'
       end
 
       def add_event_methods(event_methods)

--- a/lib/appmap/rswag.rb
+++ b/lib/appmap/rswag.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'appmap'
+
+module AppMap
+  module Rswag
+    def self.record(metadata, &block)
+      description = metadata[:full_description]
+      warn "Recording of RSwag test #{description}" if AppMap::RSpec::LOG
+      source_location = (metadata[:example_group] || {})[:location]
+
+      appmap = AppMap.record(&block)
+
+      events = appmap['events']
+      class_map = appmap['classMap']
+
+      exception = (events.last || {})[:exception]
+      failed = true if exception
+      warn "Finishing recording of #{failed ? 'failed ' : ''} RSwag test #{description}" if AppMap::RSpec::LOG
+      warn "Exception: #{exception}" if exception && AppMap::RSpec::LOG
+
+      if failed
+        warn "Failure exception: #{exception}" if AppMap::RSpec::LOG
+        test_failure = Util.extract_test_failure(exception)
+      end
+
+      AppMap::RSpec.save name: description,
+                         class_map: class_map,
+                         source_location: source_location,
+                         test_status: exception ? 'failed' : 'succeeded',
+                         test_failure: test_failure,
+                         exception: exception,
+                         events: events,
+                         frameworks: [
+                           { name: 'rswag',
+                             version: Gem.loaded_specs['rswag-specs']&.version&.to_s }
+                         ],
+                         recorder: {
+                           name: 'rswag',
+                           type: 'tests'
+                         }
+    end
+
+    class << self
+      def enabled?
+        RSpec.enabled? && defined?(Rswag)
+      end
+    end
+  end
+
+  if Rswag.enabled?
+    require 'rswag'
+    require 'rswag/specs'
+    require 'appmap/rspec'
+
+    module ::Rswag
+      module Specs
+        module ExampleHelpers
+          alias submit_request_without_appmap submit_request
+
+          def submit_request(metadata)
+            AppMap::Rswag.record(metadata) do
+              submit_request_without_appmap(metadata)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/rails7_users_app/Gemfile
+++ b/spec/fixtures/rails7_users_app/Gemfile
@@ -22,12 +22,14 @@ end
 group :test do
   gem 'database_cleaner-active_record', require: false
   gem 'database_cleaner-sequel', require: false
+  gem 'rswag'
 end
 
 group :development, :test do
   gem 'appmap', path: '../../..'
   gem 'pry-byebug', '>=0', '< 99'
   gem 'rspec-rails'
+  gem 'rswag-specs'
 end
 
 gem 'capybara', '~> 3.39', group: :test

--- a/spec/fixtures/rails7_users_app/spec/requests/users_spec.rb
+++ b/spec/fixtures/rails7_users_app/spec/requests/users_spec.rb
@@ -1,0 +1,22 @@
+require 'swagger_helper'
+require 'appmap/rswag'
+
+describe 'Users' do
+  path '/api/users' do
+    post 'Creates a user' do
+      consumes 'application/json'
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          login: { type: :string },
+          password: { type: :string }
+        },
+        required: %w[login password]
+      }
+      response 201, 'user created' do
+        let(:user) { { login: 'alice', password: 'foobar' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/fixtures/rails7_users_app/spec/swagger_helper.rb
+++ b/spec/fixtures/rails7_users_app/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('openapi').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/openapi.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'appmap-ruby fixture app for Rails 7',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -30,7 +30,7 @@ describe 'Rails' do
                 'request_method' => 'POST',
                 'normalized_path_info' => '/api/users',
                 'path_info' => '/api/users',
-                'headers' => hash_including('Content-Type' => 'application/x-www-form-urlencoded'),
+                'headers' => hash_including('Content-Type' => 'application/x-www-form-urlencoded')
               ),
               'message' => include(
                 hash_including(
@@ -55,9 +55,10 @@ describe 'Rails' do
             hash_including(
               'http_server_response' => hash_including(
                 'status_code' => 201,
-                'headers' => hash_including('Content-Type' => 'application/json; charset=utf-8'),
+                'headers' => hash_including('Content-Type' => 'application/json; charset=utf-8')
               ),
-              'return_value' => hash_including('class' => 'Hash', 'object_id' => Integer, 'properties' => include({'name' => 'login', 'class' => 'String'})),
+              'return_value' => hash_including('class' => 'Hash', 'object_id' => Integer,
+                                               'properties' => include({ 'name' => 'login', 'class' => 'String' }))
             )
           )
         end
@@ -104,7 +105,9 @@ describe 'Rails' do
         end
 
         context 'with an object-style message' do
-          let(:appmap_json_file) { 'Api_UsersController_POST_api_users_with_required_parameters_with_object-style_parameters_creates_a_user.appmap.json' }
+          let(:appmap_json_file) do
+            'Api_UsersController_POST_api_users_with_required_parameters_with_object-style_parameters_creates_a_user.appmap.json'
+          end
 
           it 'message properties are recorded in the appmap' do
             expect(events).to include(
@@ -126,7 +129,9 @@ describe 'Rails' do
 
       describe 'listing objects' do
         context 'with a custom header' do
-          let(:appmap_json_file) { 'Api_UsersController_GET_api_users_with_a_custom_header_lists_the_users.appmap.json' }
+          let(:appmap_json_file) do
+            'Api_UsersController_GET_api_users_with_a_custom_header_lists_the_users.appmap.json'
+          end
 
           it 'custom header is recorded in the appmap' do
             expect(events).to include(
@@ -167,7 +172,10 @@ describe 'Rails' do
                   'location' => 'app/views/users/index.html.haml',
                   'static' => true,
                   'labels' => [ 'mvc.template' ]
-                )))))))
+                ))
+              ))
+            ))
+          )
           expect(appmap['classMap']).to include hash_including(
             'name' => 'app',
             'children' => include(hash_including(
@@ -180,7 +188,10 @@ describe 'Rails' do
                   'location' => 'app/views/layouts/application.html.haml',
                   'static' => true,
                   'labels' => [ 'mvc.template' ]
-                )))))))
+                ))
+              ))
+            ))
+          )
         end
       end
 
@@ -253,6 +264,23 @@ describe 'Rails' do
 
     next unless rails_version == 7
 
+    describe 'rswag test' do
+      let(:appmap_json_file) do
+        'Users_api_users_post_user_created_returns_a_201_response.appmap.json'
+      end
+
+      it 'includes the rswag framework' do
+        expect(appmap['metadata']['frameworks'].map { |f| f['name'] }).to include('rswag')
+      end
+      it 'records the test status' do
+        expect(appmap['metadata'].keys).to include('test_status')
+        expect(appmap['metadata']['test_status']).to eq('succeeded')
+      end
+      it 'records the source location' do
+        expect(appmap['metadata']['source_location']).to eq('./spec/requests/users_spec.rb:16')
+      end
+    end
+
     describe 'with middleware' do
       let(:appmap_json_file) do
         'Rack_stack_changes_the_response_on_the_index_to_422.appmap.json'
@@ -290,7 +318,7 @@ describe 'Rails' do
   end
 
   describe 'with default appmap.yml' do
-    include_context 'Rails app pg database', "spec/fixtures/rails6_users_app" unless use_existing_data?
+    include_context 'Rails app pg database', 'spec/fixtures/rails6_users_app' unless use_existing_data?
     include_context 'rails integration test setup'
 
     let(:appmap_json_file) do
@@ -312,7 +340,7 @@ describe 'Rails' do
       expect(events).to include hash_including(
         'defined_class' => 'Api::UsersController',
         'method_id' => 'build_user',
-        'path' => 'app/controllers/api/users_controller.rb',
+        'path' => 'app/controllers/api/users_controller.rb'
       )
     end
   end


### PR DESCRIPTION
RSwag does all its work in a `before` hook, which doesn't work well with AppMap.

Implement an RSwag-specific recorder, and disable RSpec recording for RSwag tests.

Fixes #335 