### PR TITLE
feat: Record "around" method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+AllCops:
+  DisabledByDefault: true
+  Exclude:
+    - 'lib/**'
+    - 'test/**'
+    - 'spec/**'

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ addons:
     - postgresql-13
     - postgresql-client-13
 
+before_install:
+  - gem update --system
+
 before_deploy:
   - nvm install lts/*
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 dist: focal
 cache:
-- bundle
+- bundler
 - yarn
 
 # Travis pre-installs some Ruby versions. You can see the current list

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 # that list to not install rvm and ruby each time.
 rvm:
 - 2.6.9
-- 2.7.6
+- 2.7.5
 - 3.0.1 # doesn't show in pre-installed list
 - 3.1.2
 - 3.2.0
@@ -21,9 +21,6 @@ addons:
     packages:
     - postgresql-13
     - postgresql-client-13
-
-before_install:
-  - gem update --system
 
 before_deploy:
   - nvm install lts/*

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -1,56 +1,55 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'appmap/version'
+require "appmap/version"
 
 Gem::Specification.new do |spec|
   # ability to parameterize gem name is added intentionally,
   # to support the possibility of unofficial releases, e.g. during CI tests
-  spec.name          = ENV.fetch('GEM_ALTERNATIVE_NAME', 'appmap')
-  spec.version       = AppMap::VERSION
-  spec.authors       = ['Kevin Gilpin']
-  spec.email         = ['kgilpin@gmail.com']
+  spec.name = ENV.fetch("GEM_ALTERNATIVE_NAME", "appmap")
+  spec.version = AppMap::VERSION
+  spec.authors = ["Kevin Gilpin"]
+  spec.email = ["kgilpin@gmail.com"]
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = ">= 2.6.0"
 
-  spec.summary       = "Record the operation of a Ruby program, using the AppLand 'AppMap' format."
-  spec.homepage      = AppMap::URL
-  spec.license       = 'MIT'
+  spec.summary = "Record the operation of a Ruby program, using the AppLand 'AppMap' format."
+  spec.homepage = AppMap::URL
+  spec.license = "MIT"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = `git ls-files --no-deleted`.split("\n").grep_v(/appmap\.json$/).grep_v(%r{^(spec|test)/})
+  spec.files = `git ls-files --no-deleted`.split("\n").grep_v(/appmap\.json$/).grep_v(%r{^(spec|test)/})
 
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  spec.extensions << 'ext/appmap/extconf.rb'
-  spec.require_paths = ['lib']
+  spec.extensions << "ext/appmap/extconf.rb"
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'method_source'
-  spec.add_dependency 'reverse_markdown'
+  spec.add_dependency "method_source"
+  spec.add_dependency "reverse_markdown"
 
-  spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'rack'
+  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "rack"
 
-  spec.add_development_dependency 'bundler', '>= 1.16'
-  spec.add_development_dependency 'minitest', '~> 5.15'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '>= 12.3.3'
-  spec.add_development_dependency 'rake-compiler'
-  spec.add_development_dependency 'rdoc'
-  spec.add_development_dependency 'standardrb', "~> 1.0"
+  spec.add_development_dependency "bundler", ">= 1.16"
+  spec.add_development_dependency "minitest", "~> 5.15"
+  spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "rake", ">= 12.3.3"
+  spec.add_development_dependency "rake-compiler"
+  spec.add_development_dependency "rdoc"
 
   # Testing
-  spec.add_development_dependency 'climate_control'
-  spec.add_development_dependency 'diffy'
-  spec.add_development_dependency 'hashie'
-  spec.add_development_dependency 'launchy'
-  spec.add_development_dependency 'random-port', '~> 0.5.1'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'selenium-webdriver'
-  spec.add_development_dependency 'timecop'
-  spec.add_development_dependency 'webdrivers', '~> 4.0'
-  spec.add_development_dependency 'webrick'
+  spec.add_development_dependency "climate_control"
+  spec.add_development_dependency "diffy"
+  spec.add_development_dependency "hashie"
+  spec.add_development_dependency "launchy"
+  spec.add_development_dependency "random-port", "~> 0.5.1"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "selenium-webdriver"
+  spec.add_development_dependency "timecop"
+  spec.add_development_dependency "webdrivers", "~> 4.0"
+  spec.add_development_dependency "webrick"
 end

--- a/lib/appmap/agent.rb
+++ b/lib/appmap/agent.rb
@@ -62,10 +62,10 @@ module AppMap
       end
     end
 
-    def tracing_enabled?
+    def tracing_enabled?(thread: nil)
       return false unless @tracing
 
-      @tracing.enabled?
+      @tracing.enabled?(thread_id: thread&.object_id)
     end
 
     # Used to start tracing, stop tracing, and record events.
@@ -73,10 +73,10 @@ module AppMap
       @tracing ||= Trace::Tracing.new
     end
 
-    # Records the events which occur while processing a block,
-    # and returns an AppMap as a Hash.
-    def record
-      tracer = tracing.trace
+    # Records the events which occur while processing a block, and returns an AppMap as a Hash.
+    # Recording may optionally capture only a single thread.
+    def record(thread: nil)
+      tracer = tracing.trace(thread: thread)
       tracer.enable
       begin
         yield

--- a/lib/appmap/agent.rb
+++ b/lib/appmap/agent.rb
@@ -1,15 +1,15 @@
-require_relative 'version'
-require_relative 'hook'
-require_relative 'config'
-require_relative 'trace'
-require_relative 'class_map'
-require_relative 'metadata'
-require_relative 'util'
-require_relative 'open'
+require_relative "version"
+require_relative "hook"
+require_relative "config"
+require_relative "trace"
+require_relative "class_map"
+require_relative "metadata"
+require_relative "util"
+require_relative "open"
 
 # load extension
-require_relative 'appmap'
-require_relative './detect_enabled'
+require_relative "appmap"
+require_relative "detect_enabled"
 
 module AppMap
   class << self
@@ -25,13 +25,17 @@ module AppMap
     # Sets the configuration. This is only expected to happen once per
     # Ruby process.
     def configuration=(config)
-      warn 'AppMap is already configured' if @configuration && config
+      warn "AppMap is already configured" if @configuration && config
 
       @configuration = config
     end
 
+    def output_dir
+      ENV["APPMAP_OUTPUT_DIR"] || DEFAULT_APPMAP_DIR
+    end
+
     def default_config_file_path
-      ENV['APPMAP_CONFIG_FILE'] || 'appmap.yml'
+      ENV["APPMAP_CONFIG_FILE"] || "appmap.yml"
     end
 
     # Configures AppMap for recording. Default behavior is to configure from
@@ -84,10 +88,10 @@ module AppMap
         event_list << tracer.next_event.to_h while tracer.event?
       end
       {
-        'version' => AppMap::APPMAP_FORMAT_VERSION,
-        'metadata' => detect_metadata,
-        'classMap' => class_map(tracer.event_methods),
-        'events' => events
+        "version" => AppMap::APPMAP_FORMAT_VERSION,
+        "metadata" => detect_metadata,
+        "classMap" => class_map(tracer.event_methods),
+        "events" => events
       }
     end
 
@@ -110,11 +114,11 @@ module AppMap
     end
 
     def parameter_schema?
-      ENV['APPMAP_PARAMETER_SCHEMA'] == 'true'
+      ENV["APPMAP_PARAMETER_SCHEMA"] == "true"
     end
 
     def explain_queries?
-      ENV['APPMAP_EXPLAIN_QUERIES'] == 'true'
+      ENV["APPMAP_EXPLAIN_QUERIES"] == "true"
     end
 
     def recording_enabled?(recording_method = nil)

--- a/lib/appmap/class_map.rb
+++ b/lib/appmap/class_map.rb
@@ -69,6 +69,27 @@ module AppMap
     end
 
     class << self
+      # Labels can be embedded in the function comment. Label format is similar to YARD and JavaDoc.
+      # The keyword is @labels or @label. The keyword is followed by space-separated labels.
+      # For example:
+      # @label provider.authentication security
+      # rubocop:disable Metrics/MethodLength
+      def parse_labels(comment)
+        return [] unless comment
+
+        comment
+          .split("\n")
+          .map { |line| line.match(/^\s*#\s*@labels?\s+(.*)/) }
+          .compact
+          .map { |match| match[1] }
+          .inject([]) { |accum, labels|
+          accum += labels.split(/\s+/)
+          accum
+        }
+          .sort
+      end
+      # rubocop:enable Metrics/MethodLength
+
       def build_from_methods(methods)
         root = Types::Root.new
         methods.each do |method|
@@ -141,25 +162,6 @@ module AppMap
             end
           end
         end
-      end
-
-      # Labels can be embedded in the function comment. Label format is similar to YARD and JavaDoc.
-      # The keyword is @labels or @label. The keyword is followed by space-separated labels.
-      # For example:
-      # @label provider.authentication security
-      def parse_labels(comment)
-        return [] unless comment
-
-        comment
-          .split("\n")
-          .map { |line| line.match(/^\s*#\s*@labels?\s+(.*)/) }
-          .compact
-          .map { |match| match[1] }
-          .inject([]) { |accum, labels|
-          accum += labels.split(/\s+/)
-          accum
-        }
-          .sort
       end
 
       def find_or_create(list, info)

--- a/lib/appmap/class_map.rb
+++ b/lib/appmap/class_map.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'method_source'
+require "method_source"
 
 module AppMap
   class ClassMap
@@ -23,7 +23,7 @@ module AppMap
         include HasChildren
 
         def type
-          'package'
+          "package"
         end
 
         def to_h
@@ -38,7 +38,7 @@ module AppMap
         include HasChildren
 
         def type
-          'class'
+          "class"
         end
 
         def to_h
@@ -53,7 +53,7 @@ module AppMap
         attr_accessor :static, :location, :labels
 
         def type
-          'function'
+          "function"
         end
 
         def to_h
@@ -62,7 +62,7 @@ module AppMap
             type: type,
             location: location,
             static: static,
-            labels: labels,
+            labels: labels
           }.delete_if { |_, v| v.nil? || v == [] }
         end
       end
@@ -76,13 +76,13 @@ module AppMap
         end
 
         collapse_package = lambda do |package|
-          next unless package.type == 'package'
+          next unless package.type == "package"
 
-          while package.children.length == 1 && package.children.all? { |child| child.type == 'package' }
+          while package.children.length == 1 && package.children.all? { |child| child.type == "package" }
             child = package.children[0]
             package.children.clear
             child.children.each { |child| package.children << child }
-            package.name = [ package.name, child.name ].join('/')
+            package.name = [package.name, child.name].join("/")
           end
           package.tap do
             package.children.map(&collapse_package)
@@ -96,20 +96,20 @@ module AppMap
 
       def add_function(root, method)
         object_infos = \
-          method.package.split('/').map do |name|
+          method.package.split("/").map do |name|
             {
               name: name,
-              type: 'package'
+              type: "package"
             }
-          end + method.class_name.split('::').map do |name|
+          end + method.class_name.split("::").map do |name|
             {
               name: name,
-              type: 'class'
+              type: "class"
             }
           end
         function_info = {
           name: method.name,
-          type: 'function',
+          type: "function",
           static: method.static
         }
         location = method.source_location
@@ -118,9 +118,9 @@ module AppMap
           if location
             location_file, lineno = location
             location_file = location_file[Dir.pwd.length + 1..-1] if location_file.index(Dir.pwd) == 0
-            [ location_file, lineno ].compact.join(':')
+            [location_file, lineno].compact.join(":")
           else
-            [ method.class_name, method.static ? '.' : '#', method.name ].join
+            [method.class_name, method.static ? "." : "#", method.name].join
           end
 
         comment = method.comment
@@ -155,7 +155,10 @@ module AppMap
           .map { |line| line.match(/^\s*#\s*@labels?\s+(.*)/) }
           .compact
           .map { |match| match[1] }
-          .inject([]) { |accum, labels| accum += labels.split(/\s+/); accum }
+          .inject([]) { |accum, labels|
+          accum += labels.split(/\s+/)
+          accum
+        }
           .sort
       end
 

--- a/lib/appmap/cucumber.rb
+++ b/lib/appmap/cucumber.rb
@@ -7,7 +7,7 @@ require "fileutils"
 
 module AppMap
   module Cucumber
-    APPMAP_OUTPUT_DIR = "tmp/appmap/cucumber"
+    APPMAP_OUTPUT_DIR = File.join(AppMap.output_dir, "cucumber")
 
     ScenarioAttributes = Struct.new(:name, :feature, :feature_group)
 

--- a/lib/appmap/cucumber.rb
+++ b/lib/appmap/cucumber.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-require_relative '../appmap'
-require_relative './util'
-require_relative './detect_enabled'
-require 'fileutils'
+require_relative "../appmap"
+require_relative "util"
+require_relative "detect_enabled"
+require "fileutils"
 
 module AppMap
   module Cucumber
-    APPMAP_OUTPUT_DIR = 'tmp/appmap/cucumber'
+    APPMAP_OUTPUT_DIR = "tmp/appmap/cucumber"
 
     ScenarioAttributes = Struct.new(:name, :feature, :feature_group)
 
     ProviderStruct = Struct.new(:scenario) do
       def feature_group
         # e.g. <Cucumber::Core::Ast::Location::Precise: cucumber/api/features/authenticate.feature:1>
-        feature_path.split('/').last.split('.')[0]
+        feature_path.split("/").last.split(".")[0]
       end
     end
 
@@ -34,7 +34,7 @@ module AppMap
     # versions 4.0 and later.
     class Provider4 < ProviderStruct
       def attributes
-        ScenarioAttributes.new(scenario.name, scenario.name.split(' ')[0..1].join(' '), feature_group)
+        ScenarioAttributes.new(scenario.name, scenario.name.split(" ")[0..1].join(" "), feature_group)
       end
 
       def feature_path
@@ -46,14 +46,14 @@ module AppMap
       def init
         AppMap::DetectEnabled.discourage_conflicting_recording_methods :cucumber
 
-        warn 'Configuring AppMap recorder for Cucumber'
+        warn "Configuring AppMap recorder for Cucumber"
 
         FileUtils.mkdir_p APPMAP_OUTPUT_DIR
       end
 
       def write_scenario(scenario, appmap)
-        appmap['metadata'] = update_metadata(scenario, appmap['metadata'])
-        scenario_filename = AppMap::Util.scenario_filename(appmap['metadata']['name'])
+        appmap["metadata"] = update_metadata(scenario, appmap["metadata"])
+        scenario_filename = AppMap::Util.scenario_filename(appmap["metadata"]["name"])
 
         AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, scenario_filename), appmap)
       end
@@ -69,11 +69,11 @@ module AppMap
       protected
 
       def cucumber_version
-        Gem.loaded_specs['cucumber']&.version&.to_s
+        Gem.loaded_specs["cucumber"]&.version&.to_s
       end
 
       def provider(scenario)
-        major, = cucumber_version.split('.').map(&:to_i)
+        major, = cucumber_version.split(".").map(&:to_i)
         if major < 4
           ProviderBefore4
         else
@@ -85,19 +85,19 @@ module AppMap
         attributes = provider(scenario).attributes
 
         base_metadata.tap do |m|
-          m['name'] = attributes.name
-          m['feature'] = attributes.feature
-          m['feature_group'] = attributes.feature_group
-          m['labels'] ||= []
-          m['labels'] += (scenario.tags&.map(&:name) || [])
-          m['frameworks'] ||= []
-          m['frameworks'] << {
-            'name' => 'cucumber',
-            'version' => Gem.loaded_specs['cucumber']&.version&.to_s
+          m["name"] = attributes.name
+          m["feature"] = attributes.feature
+          m["feature_group"] = attributes.feature_group
+          m["labels"] ||= []
+          m["labels"] += (scenario.tags&.map(&:name) || [])
+          m["frameworks"] ||= []
+          m["frameworks"] << {
+            "name" => "cucumber",
+            "version" => Gem.loaded_specs["cucumber"]&.version&.to_s
           }
-          m['recorder'] = {
-            'name' => 'cucumber',
-            'type' => 'tests'
+          m["recorder"] = {
+            "name" => "cucumber",
+            "type" => "tests"
           }
         end
       end
@@ -106,7 +106,7 @@ module AppMap
 end
 
 if AppMap::Cucumber.enabled?
-  require 'appmap'
+  require "appmap"
 
   AppMap::Cucumber.run
 end

--- a/lib/appmap/detect_enabled.rb
+++ b/lib/appmap/detect_enabled.rb
@@ -1,4 +1,4 @@
-require_relative './recording_methods'
+require_relative "recording_methods"
 
 module AppMap
   # Detects whether AppMap recording should be enabled. This test can be performed generally, or for
@@ -9,27 +9,29 @@ module AppMap
     @@detected_for_method = {}
 
     class << self
+      # rubocop:disable Metrics/MethodLength
       def discourage_conflicting_recording_methods(recording_method)
-        return if ENV['APPMAP_DISCOURAGE_CONFLICTING_RECORDING_METHODS'] == 'false'
+        return if ENV["APPMAP_DISCOURAGE_CONFLICTING_RECORDING_METHODS"] == "false"
 
         return unless enabled?(recording_method.to_sym) && enabled?(:requests)
 
         warn Util.color <<~MSG, :yellow
-AppMap recording is enabled for both 'requests' and '#{recording_method}'. This is not recommended
-because the recordings will contain duplicitive information, and in some case may conflict with each other.
+          AppMap recording is enabled for both 'requests' and '#{recording_method}'. This is not recommended
+          because the recordings will contain duplicitive information, and in some case may conflict with each other.
         MSG
 
-        return unless ENV['APPMAP'] == 'true'
+        return unless ENV["APPMAP"] == "true"
 
         warn Util.color <<~MSG, :yellow
-The environment contains APPMAP=true, which is not recommended in this application environment because
-it enables all recording methods. Consider letting AppMap detect the appropriate recording method,
-or explicitly enabling only the recording methods you want to use using environment variables like
-APPMAP_RECORD_REQUESTS, APPMAP_RECORD_RSPEC, etc.
-
-See https://appmap.io/docs/reference/appmap-ruby.html#advanced-runtime-options for more information.
+          The environment contains APPMAP=true, which is not recommended in this application environment because
+          it enables all recording methods. Consider letting AppMap detect the appropriate recording method,
+          or explicitly enabling only the recording methods you want to use using environment variables like
+          APPMAP_RECORD_REQUESTS, APPMAP_RECORD_RSPEC, etc.
+          
+          See https://appmap.io/docs/reference/appmap-ruby.html#advanced-runtime-options for more information.
         MSG
       end
+      # rubocop:enable Metrics/MethodLength
 
       def enabled?(recording_method)
         new(recording_method).enabled?
@@ -57,7 +59,7 @@ See https://appmap.io/docs/reference/appmap-ruby.html#advanced-runtime-options f
 
       if @recording_method && (enabled && enabled_by_app_env?)
         warn AppMap::Util.color(
-          "AppMap #{@recording_method.nil? ? '' : "#{@recording_method} "}recording is enabled because #{message}", :magenta
+          "AppMap #{@recording_method.nil? ? "" : "#{@recording_method} "}recording is enabled because #{message}", :magenta
         )
       end
 
@@ -77,63 +79,63 @@ See https://appmap.io/docs/reference/appmap-ruby.html#advanced-runtime-options f
       message, enabled = []
       message, enabled = method(detection_functions.shift).call while enabled.nil? && !detection_functions.empty?
 
-      return [ 'it is not enabled by any configuration or framework', false, false ] if enabled.nil?
+      return ["it is not enabled by any configuration or framework", false, false] if enabled.nil?
 
       _, enabled_by_env = enabled_by_app_env?
-      [ message, enabled, enabled_by_env ]
+      [message, enabled, enabled_by_env]
     end
 
     def enabled_by_testing?
       return unless %i[rspec minitest cucumber].member?(@recording_method)
 
-      [ "running tests with #{@recording_method}", true ]
+      ["running tests with #{@recording_method}", true]
     end
 
     def enabled_by_app_env?
       env_name, app_env = detect_app_env
-      return [ "#{env_name} is '#{app_env}'", true ] if @recording_method.nil? && %w[test development].member?(app_env)
+      return ["#{env_name} is '#{app_env}'", true] if @recording_method.nil? && %w[test development].member?(app_env)
 
       return unless %i[remote requests].member?(@recording_method)
-      return [ "#{env_name} is '#{app_env}'", true ] if app_env == 'development'
+      ["#{env_name} is '#{app_env}'", true] if app_env == "development"
     end
 
     def detect_app_env
       if rails_env
-        [ 'RAILS_ENV', rails_env ]
-      elsif ENV['APP_ENV']
-        [ 'APP_ENV', ENV['APP_ENV']]
+        ["RAILS_ENV", rails_env]
+      elsif ENV["APP_ENV"]
+        ["APP_ENV", ENV["APP_ENV"]]
       end
     end
 
     def globally_enabled?
       # Don't auto-enable request recording in the 'test' environment, because users probably don't want
       # AppMaps of both test cases and requests. Requests recording can always be enabled by APPMAP_RECORD_REQUESTS=true.
-      requests_recording_in_test = -> { [ :requests ].member?(@recording_method) && detect_app_env == 'test' }
-      [ 'APPMAP=true', true ] if ENV['APPMAP'] == 'true' && !requests_recording_in_test.call
+      requests_recording_in_test = -> { [:requests].member?(@recording_method) && detect_app_env == "test" }
+      ["APPMAP=true", true] if ENV["APPMAP"] == "true" && !requests_recording_in_test.call
     end
 
     def globally_disabled?
-      [ 'APPMAP=false', false ] if ENV['APPMAP'] == 'false'
+      ["APPMAP=false", false] if ENV["APPMAP"] == "false"
     end
 
     def recording_method_disabled?
       return false unless @recording_method
 
-      env_var = [ 'APPMAP', 'RECORD', @recording_method.upcase ].join('_')
-      [ "#{[ 'APPMAP', 'RECORD', @recording_method.upcase ].join('_')}=false", false ] if ENV[env_var] == 'false'
+      env_var = ["APPMAP", "RECORD", @recording_method.upcase].join("_")
+      ["#{["APPMAP", "RECORD", @recording_method.upcase].join("_")}=false", false] if ENV[env_var] == "false"
     end
 
     def recording_method_enabled?
       return false unless @recording_method
 
-      env_var = [ 'APPMAP', 'RECORD', @recording_method.upcase ].join('_')
-      [ "#{[ 'APPMAP', 'RECORD', @recording_method.upcase ].join('_')}=true", true ] if ENV[env_var] == 'true'
+      env_var = ["APPMAP", "RECORD", @recording_method.upcase].join("_")
+      ["#{["APPMAP", "RECORD", @recording_method.upcase].join("_")}=true", true] if ENV[env_var] == "true"
     end
 
     def rails_env
       return Rails.env if defined?(::Rails::Railtie)
 
-      ENV.fetch('RAILS_ENV', nil)
+      ENV.fetch("RAILS_ENV", nil)
     end
   end
 end

--- a/lib/appmap/gem_hooks/activejob.yml
+++ b/lib/appmap/gem_hooks/activejob.yml
@@ -1,6 +1,5 @@
 - method: ActiveJob::Enqueuing#enqueue
   label: job.create
 - methods:
-  - ActiveJob::Execution#perform
   - ActiveJob::Execution#perform_now
   label: job.perform

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'English'
-require_relative './hook_log'
+require "English"
+require_relative "hook_log"
 
 module AppMap
   class Hook
     OBJECT_INSTANCE_METHODS = %i[! != !~ <=> == === =~ __id__ __send__ class clone define_singleton_method display dup
-                                 enum_for eql? equal? extend freeze frozen? hash inspect instance_eval instance_exec instance_of? instance_variable_defined? instance_variable_get instance_variable_set instance_variables is_a? itself kind_of? method methods nil? object_id private_methods protected_methods public_method public_methods public_send remove_instance_variable respond_to? send singleton_class singleton_method singleton_methods taint tainted? tap then to_enum to_s to_h to_a trust untaint untrust untrusted? yield_self].freeze
+      enum_for eql? equal? extend freeze frozen? hash inspect instance_eval instance_exec instance_of? instance_variable_defined? instance_variable_get instance_variable_set instance_variables is_a? itself kind_of? method methods nil? object_id private_methods protected_methods public_method public_methods public_send remove_instance_variable respond_to? send singleton_class singleton_method singleton_methods taint tainted? tap then to_enum to_s to_h to_a trust untaint untrust untrusted? yield_self].freeze
     OBJECT_STATIC_METHODS = %i[! != !~ < <= <=> == === =~ > >= __id__ __send__ alias_method allocate ancestors attr
-                               attr_accessor attr_reader attr_writer autoload autoload? class class_eval class_exec class_variable_defined? class_variable_get class_variable_set class_variables clone const_defined? const_get const_missing const_set constants define_method define_singleton_method deprecate_constant display dup enum_for eql? equal? extend freeze frozen? hash include include? included_modules inspect instance_eval instance_exec instance_method instance_methods instance_of? instance_variable_defined? instance_variable_get instance_variable_set instance_variables is_a? itself kind_of? method method_defined? methods module_eval module_exec name new nil? object_id prepend private_class_method private_constant private_instance_methods private_method_defined? private_methods protected_instance_methods protected_method_defined? protected_methods public_class_method public_constant public_instance_method public_instance_methods public_method public_method_defined? public_methods public_send remove_class_variable remove_instance_variable remove_method respond_to? send singleton_class singleton_class? singleton_method singleton_methods superclass taint tainted? tap then to_enum to_s trust undef_method untaint untrust untrusted? yield_self].freeze
+      attr_accessor attr_reader attr_writer autoload autoload? class class_eval class_exec class_variable_defined? class_variable_get class_variable_set class_variables clone const_defined? const_get const_missing const_set constants define_method define_singleton_method deprecate_constant display dup enum_for eql? equal? extend freeze frozen? hash include include? included_modules inspect instance_eval instance_exec instance_method instance_methods instance_of? instance_variable_defined? instance_variable_get instance_variable_set instance_variables is_a? itself kind_of? method method_defined? methods module_eval module_exec name new nil? object_id prepend private_class_method private_constant private_instance_methods private_method_defined? private_methods protected_instance_methods protected_method_defined? protected_methods public_class_method public_constant public_instance_method public_instance_methods public_method public_method_defined? public_methods public_send remove_class_variable remove_instance_variable remove_method respond_to? send singleton_class singleton_class? singleton_method singleton_methods superclass taint tainted? tap then to_enum to_s trust undef_method untaint untrust untrusted? yield_self].freeze
     SLOW_PACKAGE_THRESHOLD = 0.001
 
     @unbound_method_arity = ::UnboundMethod.instance_method(:arity)
@@ -39,9 +39,9 @@ module AppMap
       def qualify_method_name(method)
         if method.owner.singleton_class?
           class_name = singleton_method_owner_name(method)
-          [class_name, '.', method.name]
+          [class_name, ".", method.name]
         else
-          [method.owner.name, '#', method.name]
+          [method.owner.name, "#", method.name]
         end
       end
     end
@@ -55,7 +55,7 @@ module AppMap
 
     # Observe class loading and hook all methods which match the config.
     def enable(&block)
-      require 'appmap/hook/method'
+      require "appmap/hook/method"
 
       hook_builtins
 
@@ -66,7 +66,7 @@ module AppMap
       @module_load_times = Hash.new { |memo, k| memo[k] = 0 }
       @slow_packages = Set.new
 
-      if ENV['APPMAP_PROFILE_HOOK'] == 'true'
+      if ENV["APPMAP_PROFILE_HOOK"] == "true"
         dump_times = lambda do
           @module_load_times
             .keys
@@ -80,7 +80,7 @@ module AppMap
           end
         end
 
-        at_exit &dump_times
+        at_exit(&dump_times)
         Thread.new do
           while true
             dump_times.call
@@ -102,7 +102,7 @@ module AppMap
         hooks_by_class.each do |class_name, hooks|
           Array(hooks).each do |hook|
             HookLog.builtin class_name do
-              if builtin && hook.package.require_name && hook.package.require_name != 'ruby'
+              if builtin && hook.package.require_name && hook.package.require_name != "ruby"
                 begin
                   require hook.package.require_name
                 rescue
@@ -110,39 +110,59 @@ module AppMap
                   next
                 end
               end
-  
+
               begin
                 base_cls = Object.const_get class_name
               rescue NameError
                 HookLog.load_error class_name, "Class #{class_name} not found in global scope" if HookLog.enabled?
                 next
               end
-  
+
               Array(hook.method_names).each do |method_name|
                 method_name = method_name.to_sym
-  
+
                 hook_method = lambda do |entry|
                   cls, method = entry
                   next if config.never_hook?(cls, method)
-  
+
                   hook.package.handler_class.new(hook.package, cls, method).activate
                 end
-  
+
                 methods = []
                 # irb(main):001:0> Kernel.public_instance_method(:system)
                 # (irb):1:in `public_instance_method': method `system' for module `Kernel' is  private (NameError)
                 if base_cls == Kernel
-                  methods << [base_cls, base_cls.instance_method(method_name)] rescue nil
+                  begin
+                    methods << [base_cls, base_cls.instance_method(method_name)]
+                  rescue
+                    nil
+                  end
                 end
-                methods << [base_cls, base_cls.public_instance_method(method_name)] rescue nil
-                methods << [base_cls, base_cls.protected_instance_method(method_name)] rescue nil
+                begin
+                  methods << [base_cls, base_cls.public_instance_method(method_name)]
+                rescue
+                  nil
+                end
+                begin
+                  methods << [base_cls, base_cls.protected_instance_method(method_name)]
+                rescue
+                  nil
+                end
                 if base_cls.respond_to?(:singleton_class)
-                  methods << [base_cls.singleton_class, base_cls.singleton_class.public_instance_method(method_name)] rescue nil
-                  methods << [base_cls.singleton_class, base_cls.singleton_class.protected_instance_method(method_name)] rescue nil
+                  begin
+                    methods << [base_cls.singleton_class, base_cls.singleton_class.public_instance_method(method_name)]
+                  rescue
+                    nil
+                  end
+                  begin
+                    methods << [base_cls.singleton_class, base_cls.singleton_class.protected_instance_method(method_name)]
+                  rescue
+                    nil
+                  end
                 end
                 methods.compact!
                 if methods.empty?
-                  HookLog.load_error [ base_cls.name, method_name ].join('[#.]'), "Method #{method_name} not found on #{base_cls.name}" if HookLog.enabled?
+                  HookLog.load_error [base_cls.name, method_name].join("[#.]"), "Method #{method_name} not found on #{base_cls.name}" if HookLog.enabled?
                 else
                   methods.each(&hook_method)
                 end
@@ -152,13 +172,13 @@ module AppMap
         end
       end
 
-      hook_loaded_code.(config.builtin_hooks, true)
+      hook_loaded_code.call(config.builtin_hooks, true)
     end
 
     protected
 
     def trace_location(trace_point)
-      [trace_point.path, trace_point.lineno].join(':')
+      [trace_point.path, trace_point.lineno].join(":")
     end
 
     def trace_end(trace_point)
@@ -168,7 +188,7 @@ module AppMap
         path = trace_point.path
         enabled = !@notrace_paths.member?(path) && config.path_enabled?(path)
         unless enabled
-          HookLog.log 'Not hooking - path is not enabled' if HookLog.enabled?
+          HookLog.log "Not hooking - path is not enabled" if HookLog.enabled?
           @notrace_paths << path
           next
         end
@@ -178,23 +198,23 @@ module AppMap
         instance_methods = cls.public_instance_methods(false) + cls.protected_instance_methods(false) - OBJECT_INSTANCE_METHODS
         # NoMethodError: private method `singleton_class' called for Rack::MiniProfiler:Class
         class_methods = begin
-            if cls.respond_to?(:singleton_class)
-              cls.singleton_class.public_instance_methods(false) + cls.singleton_class.protected_instance_methods(false) - instance_methods - OBJECT_STATIC_METHODS
-            else
-              []
-            end
-          rescue NameError
+          if cls.respond_to?(:singleton_class)
+            cls.singleton_class.public_instance_methods(false) + cls.singleton_class.protected_instance_methods(false) - instance_methods - OBJECT_STATIC_METHODS
+          else
             []
           end
+        rescue NameError
+          []
+        end
 
         hook = lambda do |hook_cls|
           lambda do |method_id|
             method = begin
-                hook_cls.instance_method(method_id)
-              rescue NameError
-                HookLog.load_error [ hook_cls, method_id ].join('[#.]'), "Method #{hook_cls} #{method_id} is not accessible: #{$!}" if HookLog.enabled?
-                next
-              end
+              hook_cls.instance_method(method_id)
+            rescue NameError
+              HookLog.load_error [hook_cls, method_id].join("[#.]"), "Method #{hook_cls} #{method_id} is not accessible: #{$!}" if HookLog.enabled?
+              next
+            end
 
             package = config.lookup_package(hook_cls, method)
             # doing this check first returned early in 98.7% of cases in sample_app_6th_ed
@@ -202,7 +222,7 @@ module AppMap
 
             # Don't try and trace the AppMap methods or there will be
             # a stack overflow in the defined hook method.
-            next if %w[Marshal AppMap ActiveSupport].member?((hook_cls&.name || '').split('::')[0])
+            next if %w[Marshal AppMap ActiveSupport].member?((hook_cls&.name || "").split("::")[0])
 
             next if method_id == :call
 
@@ -220,10 +240,10 @@ module AppMap
         end
 
         start = Time.now
-        instance_methods.each(&hook.(cls))
+        instance_methods.each(&hook.call(cls))
         begin
           # NoMethodError: private method `singleton_class' called for Rack::MiniProfiler:Class
-          class_methods.each(&hook.(cls.singleton_class)) if cls.respond_to?(:singleton_class)
+          class_methods.each(&hook.call(cls.singleton_class)) if cls.respond_to?(:singleton_class)
         rescue NameError
           # NameError:
           #   uninitialized constant Faraday::Connection
@@ -231,12 +251,12 @@ module AppMap
         end
         elapsed = Time.now - start
         if location.index(Bundler.bundle_path.to_s) == 0
-          package_tokens = location[Bundler.bundle_path.to_s.length + 1..-1].split('/')
+          package_tokens = location[Bundler.bundle_path.to_s.length + 1..-1].split("/")
           @module_load_times[package_tokens[1]] += elapsed
         else
           file_path = location[Dir.pwd.length + 1..-1]
           if file_path
-            location = file_path.split('/', 3)[0..1].join('/')
+            location = file_path.split("/", 3)[0..1].join("/")
             @module_load_times[location] += elapsed
           end
         end

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -36,14 +36,15 @@ module AppMap
     # Single hooked method.
     # Call #activate to override the original.
     class Method
-      attr_reader :hook_package, :hook_class, :hook_method, :parameters, :arity
+      attr_reader :hook_package, :hook_class, :hook_method, :record_around, :parameters, :arity
 
       HOOK_DISABLE_KEY = "AppMap::Hook.disable"
 
-      def initialize(hook_package, hook_class, hook_method)
+      def initialize(hook_package, hook_class, hook_method, record_around: false)
         @hook_package = hook_package
         @hook_class = hook_class
         @hook_method = hook_method
+        @record_around = record_around
         @parameters = hook_method.parameters
         @arity = hook_method.arity
       end

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -92,7 +92,7 @@ module AppMap
       end
 
       def trace?
-        return false unless AppMap.tracing_enabled?
+        return false unless AppMap.tracing_enabled?(thread: Thread.current)
         return false if Thread.current[HOOK_DISABLE_KEY]
         return false if hook_package&.shallow? && AppMap.tracing.last_package_for_current_thread == hook_package
 

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
-require 'appmap/util'
+require "appmap/util"
 
 module AppMap
   class Hook
     class << self
       def method_hash_key(cls, method)
-        [ cls, method.name ].hash
+        [cls, method.name].hash
       rescue TypeError => e
         warn "Error building hash key for #{cls}, #{method}: #{e}"
       end
     end
-    
 
     SIGNATURES = {}
     LOOKUP_SIGNATURE = lambda do |id|
@@ -32,14 +31,14 @@ module AppMap
       method
     end
 
-    RUBY_MAJOR_VERSION, RUBY_MINOR_VERSION, _ = RUBY_VERSION.split('.').map(&:to_i)
+    RUBY_MAJOR_VERSION, RUBY_MINOR_VERSION, _ = RUBY_VERSION.split(".").map(&:to_i)
 
     # Single hooked method.
     # Call #activate to override the original.
     class Method
       attr_reader :hook_package, :hook_class, :hook_method, :parameters, :arity
 
-      HOOK_DISABLE_KEY = 'AppMap::Hook.disable'
+      HOOK_DISABLE_KEY = "AppMap::Hook.disable"
 
       def initialize(hook_package, hook_class, hook_method)
         @hook_package = hook_package
@@ -52,11 +51,11 @@ module AppMap
       def activate
         if HookLog.enabled?
           msg = if method_display_name
-              "#{method_display_name}"
-            else
-              "#{hook_method.name} (class resolution deferred)"
-            end
-          HookLog.log "Hooking #{msg} at line #{(hook_method.source_location || []).join(':')}"
+            "#{method_display_name}"
+          else
+            "#{hook_method.name} (class resolution deferred)"
+          end
+          HookLog.log "Hooking #{msg} at line #{(hook_method.source_location || []).join(":")}"
         end
 
         hook_method_parameters = hook_method.parameters.dup.freeze
@@ -79,13 +78,13 @@ module AppMap
 
       def defining_class(hook_class)
         cls = if RUBY_MAJOR_VERSION == 2 && RUBY_MINOR_VERSION <= 5
-            hook_class
-              .ancestors
-              .select { |cls| cls.method_defined?(hook_method.name) }
-              .find { |cls| cls.instance_method(hook_method.name).owner == cls }
-          else
-            hook_class.ancestors.find { |cls| cls.method_defined?(hook_method.name, false) }
-          end
+          hook_class
+            .ancestors
+            .select { |cls| cls.method_defined?(hook_method.name) }
+            .find { |cls| cls.instance_method(hook_method.name).owner == cls }
+        else
+          hook_class.ancestors.find { |cls| cls.method_defined?(hook_method.name, false) }
+        end
 
         return cls if cls
 
@@ -103,7 +102,7 @@ module AppMap
       def method_display_name
         return @method_display_name if @method_display_name
 
-        return @method_display_name = [defined_class, '#', hook_method.name].join if defined_class
+        return @method_display_name = [defined_class, "#", hook_method.name].join if defined_class
 
         "#{hook_method.name} (class resolution deferred)"
       end
@@ -114,7 +113,7 @@ module AppMap
 
       def after_hook(_receiver, call_event, elapsed_before, elapsed, after_start_time, return_value, exception)
         return_event = handle_return(call_event.id, elapsed, return_value, exception)
-        return_event.elapsed_instrumentation = elapsed_before + (AppMap::Util.gettime() - after_start_time)
+        return_event.elapsed_instrumentation = elapsed_before + (AppMap::Util.gettime - after_start_time)
         AppMap.tracing.record_event(return_event) if return_event
       end
 
@@ -141,20 +140,20 @@ module AppMap
   end
 end
 
-unless ENV['APPMAP_NO_PATCH_OBJECT'] == 'true'
+unless ENV["APPMAP_NO_PATCH_OBJECT"] == "true"
   class Object
     prepend AppMap::ObjectMethods
   end
 end
 
-unless ENV['APPMAP_NO_PATCH_MODULE'] == 'true'
+unless ENV["APPMAP_NO_PATCH_MODULE"] == "true"
   class Module
     prepend AppMap::ModuleMethods
   end
 end
 
-if RUBY_VERSION < '3'
-  require 'appmap/hook/method/ruby2'
+if RUBY_VERSION < "3"
+  require "appmap/hook/method/ruby2"
 else
-  require 'appmap/hook/method/ruby3'
+  require "appmap/hook/method/ruby3"
 end

--- a/lib/appmap/hook/method/ruby3.rb
+++ b/lib/appmap/hook/method/ruby3.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'appmap/util'
+require "appmap/util"
 
 module AppMap
   class Hook
@@ -19,7 +19,7 @@ module AppMap
       protected
 
       def before_hook(receiver, *args, **kwargs)
-        before_hook_start_time = AppMap::Util.gettime()
+        before_hook_start_time = AppMap::Util.gettime
         args = [*args, kwargs] if !kwargs.empty? || keyrest?
         call_event = handle_call(receiver, args)
         if call_event
@@ -29,29 +29,29 @@ module AppMap
             defined_class: defined_class,
             method: hook_method
         end
-        [call_event, AppMap::Util.gettime() - before_hook_start_time]
+        [call_event, AppMap::Util.gettime - before_hook_start_time]
       end
 
       def keyrest?
         @keyrest ||= parameters.map(&:last).include? :keyrest
       end
 
-      def do_call(receiver, *args, **kwargs, &block)
-        hook_method.bind_call(receiver, *args, **kwargs, &block)
+      def do_call(receiver, ...)
+        hook_method.bind_call(receiver, ...)
       end
 
       # rubocop:disable Metrics/MethodLength
-      def trace_call(call_event, elapsed_before, receiver, *args, **kwargs, &block)
-        return do_call(receiver, *args, **kwargs, &block) unless call_event
+      def trace_call(call_event, elapsed_before, receiver, ...)
+        return do_call(receiver, ...) unless call_event
 
-        start_time = AppMap::Util.gettime()
+        start_time = AppMap::Util.gettime
         begin
-          return_value = do_call(receiver, *args, **kwargs, &block)
+          return_value = do_call(receiver, ...)
         rescue # rubocop:disable Style/RescueStandardError
           exception = $ERROR_INFO
           raise
         ensure
-          after_start_time = AppMap::Util.gettime()
+          after_start_time = AppMap::Util.gettime
           with_disabled_hook { after_hook receiver, call_event, elapsed_before, after_start_time - start_time, after_start_time, return_value, exception } \
             if call_event
         end

--- a/lib/appmap/hook/record_around.rb
+++ b/lib/appmap/hook/record_around.rb
@@ -1,0 +1,77 @@
+module AppMap
+  class Hook
+    # Start and stop a recording around a Hook::Method.
+    module RecordAround
+      APPMAP_OUTPUT_DIR = File.join(AppMap.output_dir, "requests")
+
+      # Context for a recording.
+      class Context
+        attr_reader :hook_method
+
+        def initialize(hook_method)
+          @hook_method = hook_method
+          @start_time = DateTime.now
+          @tracer = AppMap.tracing.trace(thread: Thread.current)
+        end
+
+        # Finish recording the AppMap by collecting the events and classMap and writing the output file.
+        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/AbcSize
+        def finish
+          return unless @tracer
+
+          tracer = @tracer
+          @tracer = nil
+          AppMap.tracing.delete(tracer)
+
+          events = tracer.events.map(&:to_h)
+
+          timestamp = DateTime.now
+          appmap_name = "#{hook_method.name} (#{Thread.current.object_id}) - #{timestamp.strftime("%T.%L")}"
+          appmap_file_name = AppMap::Util.scenario_filename([timestamp.to_f, hook_method.name, Thread.current.object_id].join("_"))
+
+          metadata = AppMap.detect_metadata.tap do |metadata|
+            metadata[:name] = appmap_name
+            metadata[:source_location] = hook_method.source_location
+            metadata[:recorder] = {
+              name: "command",
+              type: "requests"
+            }
+          end
+
+          appmap = {
+            version: AppMap::APPMAP_FORMAT_VERSION,
+            classMap: AppMap.class_map(tracer.event_methods),
+            metadata: metadata,
+            events: events
+          }
+
+          AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, appmap_file_name), appmap)
+        end
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/AbcSize
+      end
+
+      # If requests recording is enabled, and we encounter a method which should always be recorded
+      # when requests recording is on, and there is no other recording in progress, then start a
+      # new recording and end it when the method returns.
+      def record_around?
+        (record_around && AppMap.recording_enabled?(:requests) && !AppMap.tracing_enabled?(thread: Thread.current))
+      end
+
+      def record_around_before
+        return unless record_around?
+
+        @record_around_context = Context.new(hook_method)
+      end
+
+      def record_around_after
+        return unless @record_around_context
+
+        context = @record_around_context
+        @record_around_context = nil
+        context.finish
+      end
+    end
+  end
+end

--- a/lib/appmap/metadata.rb
+++ b/lib/appmap/metadata.rb
@@ -17,7 +17,8 @@ module AppMap
             name: "appmap",
             url: AppMap::URL,
             version: AppMap::VERSION
-          }
+          },
+          timestamp: DateTime.now.iso8601
         }.tap do |m|
           if defined?(::Rails) && defined?(::Rails.version)
             m[:frameworks] ||= []

--- a/lib/appmap/metadata.rb
+++ b/lib/appmap/metadata.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'appmap/util'
+require "appmap/util"
 
 module AppMap
   module Metadata
@@ -9,12 +9,12 @@ module AppMap
         {
           app: AppMap.configuration.name,
           language: {
-            name: 'ruby',
+            name: "ruby",
             engine: RUBY_ENGINE,
             version: RUBY_VERSION
           },
           client: {
-            name: 'appmap',
+            name: "appmap",
             url: AppMap::URL,
             version: AppMap::VERSION
           }
@@ -22,7 +22,7 @@ module AppMap
           if defined?(::Rails) && defined?(::Rails.version)
             m[:frameworks] ||= []
             m[:frameworks] << {
-              name: 'rails',
+              name: "rails",
               version: ::Rails.version
             }
           end
@@ -33,7 +33,7 @@ module AppMap
       protected
 
       def git_available
-        @git_available = system('git status 2>&1 > /dev/null') if @git_available.nil?
+        @git_available = system("git status 2>&1 > /dev/null") if @git_available.nil?
       end
 
       def git_metadata
@@ -45,8 +45,20 @@ module AppMap
         git_last_annotated_tag = nil if Util.blank?(git_last_annotated_tag)
         git_last_tag = `git describe --abbrev=0 --tags 2>/dev/null`.strip
         git_last_tag = nil if Util.blank?(git_last_tag)
-        git_commits_since_last_annotated_tag = `git describe`.strip =~ /-(\d+)-(\w+)$/[1] rescue 0 if git_last_annotated_tag
-        git_commits_since_last_tag = `git describe --tags`.strip =~ /-(\d+)-(\w+)$/[1] rescue 0 if git_last_tag
+        if git_last_annotated_tag
+          git_commits_since_last_annotated_tag = begin
+            `git describe`.strip =~ /-(\d+)-(\w+)$/[1]
+          rescue
+            0
+          end
+        end
+        if git_last_tag
+          git_commits_since_last_tag = begin
+            `git describe --tags`.strip =~ /-(\d+)-(\w+)$/[1]
+          rescue
+            0
+          end
+        end
 
         {
           repository: git_repo,

--- a/lib/appmap/metadata.rb
+++ b/lib/appmap/metadata.rb
@@ -18,7 +18,7 @@ module AppMap
             url: AppMap::URL,
             version: AppMap::VERSION
           },
-          timestamp: DateTime.now.iso8601
+          timestamp: Time.now.to_f
         }.tap do |m|
           if defined?(::Rails) && defined?(::Rails.version)
             m[:frameworks] ||= []

--- a/lib/appmap/metadata.rb
+++ b/lib/appmap/metadata.rb
@@ -40,35 +40,11 @@ module AppMap
         git_repo = `git config --get remote.origin.url`.strip
         git_branch = `git rev-parse --abbrev-ref HEAD`.strip
         git_sha = `git rev-parse HEAD`.strip
-        git_status = `git status -s`.split("\n").map(&:strip)
-        git_last_annotated_tag = `git describe --abbrev=0 2>/dev/null`.strip
-        git_last_annotated_tag = nil if Util.blank?(git_last_annotated_tag)
-        git_last_tag = `git describe --abbrev=0 --tags 2>/dev/null`.strip
-        git_last_tag = nil if Util.blank?(git_last_tag)
-        if git_last_annotated_tag
-          git_commits_since_last_annotated_tag = begin
-            `git describe`.strip =~ /-(\d+)-(\w+)$/[1]
-          rescue
-            0
-          end
-        end
-        if git_last_tag
-          git_commits_since_last_tag = begin
-            `git describe --tags`.strip =~ /-(\d+)-(\w+)$/[1]
-          rescue
-            0
-          end
-        end
 
         {
           repository: git_repo,
           branch: git_branch,
-          commit: git_sha,
-          status: git_status,
-          git_last_annotated_tag: git_last_annotated_tag,
-          git_last_tag: git_last_tag,
-          git_commits_since_last_annotated_tag: git_commits_since_last_annotated_tag,
-          git_commits_since_last_tag: git_commits_since_last_tag
+          commit: git_sha
         }
       end
     end

--- a/lib/appmap/metadata.rb
+++ b/lib/appmap/metadata.rb
@@ -17,8 +17,7 @@ module AppMap
             name: "appmap",
             url: AppMap::URL,
             version: AppMap::VERSION
-          },
-          timestamp: Time.now.to_f
+          }
         }.tap do |m|
           if defined?(::Rails) && defined?(::Rails.version)
             m[:frameworks] ||= []

--- a/lib/appmap/middleware/remote_recording.rb
+++ b/lib/appmap/middleware/remote_recording.rb
@@ -6,7 +6,7 @@ module AppMap
     # It can also be enabled to emit an AppMap for each request.
     class RemoteRecording
       def initialize(app)
-        require 'json'
+        require "json"
 
         @app = app
       end
@@ -23,18 +23,18 @@ module AppMap
       end
 
       def ws_start_recording
-        return [ 409, 'Recording is already in progress' ] if @tracer
+        return [409, "Recording is already in progress"] if @tracer
 
         @events = []
         @tracer = AppMap.tracing.trace
         @event_thread = Thread.new { event_loop }
         @event_thread.abort_on_exception = true
 
-        [ 200 ]
+        [200]
       end
 
       def ws_stop_recording(req)
-        return [ 404, 'No recording is in progress' ] unless @tracer
+        return [404, "No recording is in progress"] unless @tracer
 
         tracer = @tracer
         @tracer = nil
@@ -50,7 +50,7 @@ module AppMap
         is_control_command_event = lambda do |event|
           event[:event] == :call &&
             event[:http_server_request] &&
-            event[:http_server_request][:path_info] == '/_appmap/record'
+            event[:http_server_request][:path_info] == "/_appmap/record"
         end
         control_command_events = @events.select(&is_control_command_event)
 
@@ -63,8 +63,8 @@ module AppMap
 
         metadata = AppMap.detect_metadata
         metadata[:recorder] = {
-          name: 'remote_recording',
-          type: 'remote'
+          name: "remote_recording",
+          type: "remote"
         }
 
         response = JSON.generate \
@@ -73,7 +73,7 @@ module AppMap
           metadata: metadata,
           events: @events
 
-        [ 200, response ]
+        [200, response]
       end
 
       def call(env)
@@ -82,7 +82,7 @@ module AppMap
         # 0
 
         req = Rack::Request.new(env)
-        return handle_record_request(req) if AppMap.recording_enabled?(:remote) && req.path == '/_appmap/record'
+        return handle_record_request(req) if AppMap.recording_enabled?(:remote) && req.path == "/_appmap/record"
 
         start_time = Time.now
         # Support multi-threaded web server such as Puma by recording each thread
@@ -100,20 +100,20 @@ module AppMap
           event_fields = events.map(&:keys).flatten.map(&:to_sym).uniq.sort
           return unless %i[http_server_request http_server_response].all? { |field| event_fields.include?(field) }
 
-          path = req.path.gsub(/\/{2,}/, '/') # Double slashes have been observed
-          appmap_name = "#{req.request_method} #{path} (#{status}) - #{start_time.strftime('%T.%L')}"
-          appmap_file_name = AppMap::Util.scenario_filename([ start_time.to_f, req.url ].join('_'))
-          output_dir = File.join(AppMap::DEFAULT_APPMAP_DIR, 'requests')
+          path = req.path.gsub(/\/{2,}/, "/") # Double slashes have been observed
+          appmap_name = "#{req.request_method} #{path} (#{status}) - #{start_time.strftime("%T.%L")}"
+          appmap_file_name = AppMap::Util.scenario_filename([start_time.to_f, req.url].join("_"))
+          output_dir = File.join(AppMap::DEFAULT_APPMAP_DIR, "requests")
           appmap_file_path = File.join(output_dir, appmap_file_name)
 
           metadata = AppMap.detect_metadata
           metadata[:name] = appmap_name
           metadata[:timestamp] = start_time.to_f
           metadata[:recorder] = {
-            name: 'rack',
-            type: 'requests'
+            name: "rack",
+            type: "requests"
           }
-  
+
           appmap = {
             version: AppMap::APPMAP_FORMAT_VERSION,
             classMap: AppMap.class_map(tracer.event_methods),
@@ -124,36 +124,36 @@ module AppMap
           FileUtils.mkdir_p(output_dir)
           File.write(appmap_file_path, JSON.generate(appmap))
 
-          headers['AppMap-Name'] = File.expand_path(appmap_name)
-          headers['AppMap-File-Name'] = File.expand_path(appmap_file_path)
+          headers["AppMap-Name"] = File.expand_path(appmap_name)
+          headers["AppMap-File-Name"] = File.expand_path(appmap_file_path)
         end
 
         @app.call(env).tap(&record_request)
       end
 
       def recording_state
-        [ 200, JSON.generate({ enabled: recording? }) ]
+        [200, JSON.generate({enabled: recording?})]
       end
 
       def handle_record_request(req)
-        method = req.env['REQUEST_METHOD']
+        method = req.env["REQUEST_METHOD"]
 
         status, body = \
-          if method.eql?('GET')
+          if method.eql?("GET")
             recording_state
-          elsif method.eql?('POST')
+          elsif method.eql?("POST")
             ws_start_recording
-          elsif method.eql?('DELETE')
+          elsif method.eql?("DELETE")
             ws_stop_recording(req)
           else
-            [ 404, '' ]
+            [404, ""]
           end
 
-        [status, { 'Content-Type' => 'application/json' }, [body || '']]
+        [status, {"Content-Type" => "application/json"}, [body || ""]]
       end
 
       def html_response?(headers)
-        headers['Content-Type'] && headers['Content-Type'] =~ /html/
+        headers["Content-Type"] && headers["Content-Type"] =~ /html/
       end
 
       def record_all_requests?

--- a/lib/appmap/middleware/remote_recording.rb
+++ b/lib/appmap/middleware/remote_recording.rb
@@ -103,7 +103,7 @@ module AppMap
           path = req.path.gsub(/\/{2,}/, "/") # Double slashes have been observed
           appmap_name = "#{req.request_method} #{path} (#{status}) - #{start_time.strftime("%T.%L")}"
           appmap_file_name = AppMap::Util.scenario_filename([start_time.to_f, req.url].join("_"))
-          output_dir = File.join(AppMap::DEFAULT_APPMAP_DIR, "requests")
+          output_dir = File.join(AppMap.output_dir, "requests")
           appmap_file_path = File.join(output_dir, appmap_file_name)
 
           metadata = AppMap.detect_metadata

--- a/lib/appmap/middleware/remote_recording.rb
+++ b/lib/appmap/middleware/remote_recording.rb
@@ -108,7 +108,6 @@ module AppMap
 
           metadata = AppMap.detect_metadata
           metadata[:name] = appmap_name
-          metadata[:timestamp] = start_time.to_f
           metadata[:recorder] = {
             name: "rack",
             type: "requests"

--- a/lib/appmap/minitest.rb
+++ b/lib/appmap/minitest.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require_relative '../appmap'
-require_relative './util'
-require_relative './detect_enabled'
-require 'fileutils'
-require 'active_support'
-require 'active_support/core_ext'
+require_relative "../appmap"
+require_relative "util"
+require_relative "detect_enabled"
+require "fileutils"
+require "active_support"
+require "active_support/core_ext"
 
 module AppMap
   # Integration of AppMap with Minitest. When enabled with APPMAP=true, the AppMap tracer will
   # be activated around each test.
   module Minitest
-    APPMAP_OUTPUT_DIR = 'tmp/appmap/minitest'
-    LOG = (ENV['APPMAP_DEBUG'] == 'true' || ENV['DEBUG'] == 'true')
+    APPMAP_OUTPUT_DIR = "tmp/appmap/minitest"
+    LOG = (ENV["APPMAP_DEBUG"] == "true" || ENV["DEBUG"] == "true")
 
     def self.metadata
       AppMap.detect_metadata
@@ -28,13 +28,13 @@ module AppMap
 
       def source_location
         location = test.method(test_name).source_location
-        [ Util.normalize_path(location.first), location.last ].join(':')
+        [Util.normalize_path(location.first), location.last].join(":")
       end
 
       def finish(failures, exception)
         failed = failures.any? || exception
         if AppMap::Minitest::LOG
-          warn "Finishing recording of #{failed ? 'failed ' : ''} test #{test.class}.#{test.name}"
+          warn "Finishing recording of #{failed ? "failed " : ""} test #{test.class}.#{test.name}"
         end
         warn "Exception: #{exception}" if exception && AppMap::Minitest::LOG
 
@@ -53,17 +53,17 @@ module AppMap
 
         class_map = AppMap.class_map(@trace.event_methods)
 
-        feature_group = test.class.name.underscore.split('_')[0...-1].join('_').capitalize
-        feature_name = test.name.split('_')[1..-1].join(' ')
-        scenario_name = [feature_group, feature_name].join(' ')
+        feature_group = test.class.name.underscore.split("_")[0...-1].join("_").capitalize
+        feature_name = test.name.split("_")[1..-1].join(" ")
+        scenario_name = [feature_group, feature_name].join(" ")
 
         AppMap::Minitest.save name: scenario_name,
-                              class_map: class_map,
-                              source_location: source_location,
-                              test_status: failed ? 'failed' : 'succeeded',
-                              test_failure: test_failure,
-                              exception: exception,
-                              events: events
+          class_map: class_map,
+          source_location: source_location,
+          test_status: failed ? "failed" : "succeeded",
+          test_failure: test_failure,
+          exception: exception,
+          events: events
       end
     end
 
@@ -96,7 +96,7 @@ module AppMap
       end
 
       def config
-        @config or raise 'AppMap is not configured'
+        @config or raise "AppMap is not configured"
       end
 
       def add_event_methods(event_methods)
@@ -110,12 +110,12 @@ module AppMap
           m[:app] = AppMap.configuration.name
           m[:frameworks] ||= []
           m[:frameworks] << {
-            name: 'minitest',
-            version: Gem.loaded_specs['minitest']&.version&.to_s
+            name: "minitest",
+            version: Gem.loaded_specs["minitest"]&.version&.to_s
           }
           m[:recorder] = {
-            name: 'minitest',
-            type: 'tests'
+            name: "minitest",
+            type: "tests"
           }
           m[:test_status] = test_status
           m[:test_failure] = test_failure if test_failure
@@ -145,11 +145,11 @@ module AppMap
 end
 
 if AppMap::Minitest.enabled?
-  require 'appmap'
-  require 'minitest/test'
+  require "appmap"
+  require "minitest/test"
 
   class ::Minitest::Test
-    alias run_without_hook run
+    alias_method :run_without_hook, :run
 
     def run
       AppMap::Minitest.begin_test self, name

--- a/lib/appmap/minitest.rb
+++ b/lib/appmap/minitest.rb
@@ -11,7 +11,7 @@ module AppMap
   # Integration of AppMap with Minitest. When enabled with APPMAP=true, the AppMap tracer will
   # be activated around each test.
   module Minitest
-    APPMAP_OUTPUT_DIR = "tmp/appmap/minitest"
+    APPMAP_OUTPUT_DIR = File.join(AppMap.output_dir, "minitest")
     LOG = (ENV["APPMAP_DEBUG"] == "true" || ENV["DEBUG"] == "true")
 
     def self.metadata

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative '../appmap'
-require_relative './util'
-require_relative './detect_enabled'
-require 'set'
-require 'fileutils'
+require_relative "../appmap"
+require_relative "util"
+require_relative "detect_enabled"
+require "set"
+require "fileutils"
 
 module AppMap
   module RSpec
-    APPMAP_OUTPUT_DIR = 'tmp/appmap/rspec'
-    LOG = (ENV['APPMAP_DEBUG'] == 'true' || ENV['DEBUG'] == 'true')
+    APPMAP_OUTPUT_DIR = "tmp/appmap/rspec"
+    LOG = (ENV["APPMAP_DEBUG"] == "true" || ENV["DEBUG"] == "true")
 
     def self.metadata
       AppMap.detect_metadata
@@ -52,7 +52,7 @@ module AppMap
       end
 
       def description
-        description? ? description_args.join(' ') : nil
+        description? ? description_args.join(" ") : nil
       end
 
       def parent
@@ -69,7 +69,7 @@ module AppMap
             example_group.parent_groups.first
           end
 
-        example_group_parent == example_group ? nil : ScopeExampleGroup.new(example_group_parent)
+        (example_group_parent == example_group) ? nil : ScopeExampleGroup.new(example_group_parent)
       end
     end
 
@@ -83,7 +83,7 @@ module AppMap
           # This is the ugliest thing ever but I don't want to lose it.
           # All the WebDriver calls are getting app-mapped and it's really unclear
           # what they are.
-          page.driver.options[:http_client].instance_variable_get('@server_url').port
+          page.driver.options[:http_client].instance_variable_get(:@server_url).port
         end
 
         warn "Starting recording of example #{example}@#{source_location}" if AppMap::RSpec::LOG
@@ -92,14 +92,14 @@ module AppMap
       end
 
       def source_location
-        result = example.location_rerun_argument.split(':')[0]
-        result = result[2..-1] if result.index('./') == 0
+        result = example.location_rerun_argument.split(":")[0]
+        result = result[2..-1] if result.index("./") == 0
         result
       end
 
       def finish(failure, exception)
         failed = true if failure || exception
-        warn "Finishing recording of #{failed ? 'failed ' : ''} example #{example}" if AppMap::RSpec::LOG
+        warn "Finishing recording of #{failed ? "failed " : ""} example #{example}" if AppMap::RSpec::LOG
         warn "Exception: #{exception}" if exception && AppMap::RSpec::LOG
 
         if failed
@@ -130,21 +130,21 @@ module AppMap
         description.reverse!
 
         normalize = lambda do |desc|
-          desc.gsub('it should behave like', '')
-              .gsub(/Controller$/, '')
-              .gsub(/\s+/, ' ')
-              .strip
+          desc.gsub("it should behave like", "")
+            .gsub(/Controller$/, "")
+            .gsub(/\s+/, " ")
+            .strip
         end
 
-        full_description = normalize.call(description.join(' '))
+        full_description = normalize.call(description.join(" "))
 
         AppMap::RSpec.save name: full_description,
-                           class_map: class_map,
-                           source_location: source_location,
-                           test_status: exception ? 'failed' : 'succeeded',
-                           test_failure: test_failure,
-                           exception: exception,
-                           events: events
+          class_map: class_map,
+          source_location: source_location,
+          test_status: exception ? "failed" : "succeeded",
+          test_failure: test_failure,
+          exception: exception,
+          events: events
       end
     end
 
@@ -169,10 +169,10 @@ module AppMap
         # The example is empty except for assertions. So RSwag has its own recorder, and RSpec
         # recording is disabled so it won't clobber the AppMap with empty data.
         recording = if example.metadata[:appmap] == false || example.metadata[:rswag]
-                      :disabled
-                    else
-                      Recording.new(example)
-                    end
+          :disabled
+        else
+          Recording.new(example)
+        end
 
         @recordings_by_example[example] = recording
       end
@@ -185,7 +185,7 @@ module AppMap
       end
 
       def config
-        @config or raise 'AppMap is not configured'
+        @config or raise "AppMap is not configured"
       end
 
       def add_event_methods(event_methods)
@@ -193,20 +193,20 @@ module AppMap
       end
 
       def save(name:, class_map:, source_location:, test_status:, test_failure:, exception:, events:, frameworks: [],
-               recorder: nil)
+        recorder: nil)
         metadata = AppMap::RSpec.metadata.tap do |m|
           m[:name] = name
           m[:source_location] = source_location
           m[:app] = AppMap.configuration.name
           m[:frameworks] ||= []
           m[:frameworks] << {
-            name: 'rspec',
-            version: Gem.loaded_specs['rspec-core']&.version&.to_s
+            name: "rspec",
+            version: Gem.loaded_specs["rspec-core"]&.version&.to_s
           }
           m[:frameworks] += frameworks
           m[:recorder] = recorder || {
-            name: 'rspec',
-            type: 'tests'
+            name: "rspec",
+            type: "tests"
           }
           m[:test_status] = test_status
           m[:test_failure] = test_failure if test_failure
@@ -242,9 +242,9 @@ module AppMap
 end
 
 if AppMap::RSpec.enabled?
-  require 'active_support/inflector/transliterate'
-  require 'rspec/core'
-  require 'rspec/core/example'
+  require "active_support/inflector/transliterate"
+  require "rspec/core"
+  require "rspec/core/example"
 
   module RSpec
     module Core

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -8,7 +8,7 @@ require "fileutils"
 
 module AppMap
   module RSpec
-    APPMAP_OUTPUT_DIR = "tmp/appmap/rspec"
+    APPMAP_OUTPUT_DIR = File.join(AppMap.output_dir, "rspec")
     LOG = (ENV["APPMAP_DEBUG"] == "true" || ENV["DEBUG"] == "true")
 
     def self.metadata

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'delegate'
+require "delegate"
 
 module AppMap
   module Trace
@@ -21,7 +21,7 @@ module AppMap
       end
 
       def comment
-        return nil if source_location.nil? || source_location.first.start_with?('<')
+        return nil if source_location.nil? || source_location.first.start_with?("<")
 
         # Do not use method_source's comment method because it's slow
         @comment ||= RubyMethod.last_comment(*source_location)
@@ -103,11 +103,11 @@ module AppMap
   class StackPrinter
     class << self
       def enabled?
-        ENV['APPMAP_PRINT_STACKS'] == 'true'
+        ENV["APPMAP_PRINT_STACKS"] == "true"
       end
 
       def depth
-        (ENV['APPMAP_STACK_DEPTH'] || 20).to_i
+        (ENV["APPMAP_STACK_DEPTH"] || 20).to_i
       end
     end
 
@@ -116,21 +116,21 @@ module AppMap
     end
 
     def record(event)
-      stack = caller.select { |line| !line.index('/lib/appmap/') }[0...StackPrinter.depth].join("\n  ")
+      stack = caller.select { |line| !line.index("/lib/appmap/") }[0...StackPrinter.depth].join("\n  ")
       stack_hash = Digest::SHA256.hexdigest(stack)
       return if @@stacks[stack_hash]
 
       @@stacks[stack_hash] = stack
       puts
-      puts 'Event: ' + event.to_h.map { |k, v| [ "#{k}: #{v}" ] }.join(', ')
-      puts '  ' + stack
+      puts "Event: " + event.to_h.map { |k, v| ["#{k}: #{v}"] }.join(", ")
+      puts "  " + stack
       puts
     end
   end
 
   class Tracer
     attr_accessor :stacks
-    attr_reader   :thread_id, :events
+    attr_reader :thread_id, :events
 
     # Records the events which happen in a program.
     def initialize(thread_id: nil)

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -71,8 +71,8 @@ module AppMap
         end
       end
 
-      def enabled?
-        @tracers.any?(&:enabled?)
+      def enabled?(thread_id: nil)
+        @tracers.any? { |t| t.enabled?(thread_id: thread_id) }
       end
 
       def last_package_for_current_thread
@@ -146,8 +146,10 @@ module AppMap
       @enabled = true
     end
 
-    def enabled?
-      @enabled
+    def enabled?(thread_id: nil)
+      return false unless @enabled
+
+      thread_id.nil? || @thread_id.nil? || @thread_id == thread_id
     end
 
     # Private function. Use AppMap.tracing#delete.

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -198,6 +198,8 @@ module AppMap
       def write_appmap(filename, appmap)
         require "tmpdir"
 
+        FileUtils.mkdir_p(File.dirname(filename))
+
         # This is what Ruby Tempfile does; but we don't want the file to be unlinked.
         mode = File::RDWR | File::CREAT | File::EXCL
         ::Dir::Tmpname.create(["appmap_", ".json"]) do |tmpname|

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -1,88 +1,92 @@
 # frozen_string_literal: true
 
-require 'bundler'
-require 'fileutils'
+require "bundler"
+require "fileutils"
 
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/ModuleLength
+# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/AbcSize
 module AppMap
   module Util
     # https://wynnnetherland.com/journal/a-stylesheet-author-s-guide-to-terminal-colors/
     # Embed in a String to clear all previous ANSI sequences.
-    CLEAR   = "\e[0m"
-    BOLD    = "\e[1m"
+    CLEAR = "\e[0m"
+    BOLD = "\e[1m"
 
     # Colors
-    BLACK   = "\e[30m"
-    RED     = "\e[31m"
-    GREEN   = "\e[32m"
-    YELLOW  = "\e[33m"
-    BLUE    = "\e[34m"
+    BLACK = "\e[30m"
+    RED = "\e[31m"
+    GREEN = "\e[32m"
+    YELLOW = "\e[33m"
+    BLUE = "\e[34m"
     MAGENTA = "\e[35m"
-    CYAN    = "\e[36m"
-    WHITE   = "\e[37m"
+    CYAN = "\e[36m"
+    WHITE = "\e[37m"
 
     class << self
       def parse_function_name(name)
-        package_tokens = name.split('/')
+        package_tokens = name.split("/")
 
         class_and_name = package_tokens.pop
-        class_name, function_name, static = if class_and_name.include?('.')
-                                              class_and_name.split('.',
-                                                                   2) + [ true ]
-                                            else
-                                              class_and_name.split(
-                                                '#', 2
-                                              ) + [ false ]
-                                            end
+        class_name, function_name, static = if class_and_name.include?(".")
+          class_and_name.split(".",
+            2) + [true]
+        else
+          class_and_name.split(
+            "#", 2
+          ) + [false]
+        end
 
         raise "Malformed fully-qualified function name #{name}" unless function_name
 
-        [ package_tokens.empty? ? 'ruby' : package_tokens.join('/'), class_name, static, function_name ]
+        [package_tokens.empty? ? "ruby" : package_tokens.join("/"), class_name, static, function_name]
       end
 
       # scenario_filename builds a suitable file name from a scenario name.
       # Special characters are removed, and the file name is truncated to fit within
       # shell limitations.
-      def scenario_filename(name, max_length: 255, separator: '_', extension: '.appmap.json')
+      def scenario_filename(name, max_length: 255, separator: "_", extension: ".appmap.json")
         # Cribbed from v5 version of ActiveSupport:Inflector#parameterize:
         # https://github.com/rails/rails/blob/v5.2.4/activesupport/lib/active_support/inflector/transliterate.rb#L92
         # Replace accented chars with their ASCII equivalents.
 
-        fname = name.encode('utf-8', invalid: :replace, undef: :replace, replace: '_')
+        fname = name.encode("utf-8", invalid: :replace, undef: :replace, replace: "_")
 
         # Turn unwanted chars into the separator.
         fname.gsub!(/[^a-z0-9\-_]+/i, separator)
 
         re_sep = Regexp.escape(separator)
-        re_duplicate_separator        = /#{re_sep}{2,}/
+        re_duplicate_separator = /#{re_sep}{2,}/
         re_leading_trailing_separator = /^#{re_sep}|#{re_sep}$/i
 
         # No more than one of the separator in a row.
         fname.gsub!(re_duplicate_separator, separator)
 
         # Finally, Remove leading/trailing separator.
-        fname.gsub!(re_leading_trailing_separator, '')
+        fname.gsub!(re_leading_trailing_separator, "")
 
         if (fname.length + extension.length) > max_length
-          require 'base64'
-          require 'digest'
+          require "base64"
+          require "digest"
           fname_digest = Base64.urlsafe_encode64 Digest::MD5.digest(fname), padding: false
-          fname[max_length - fname_digest.length - extension.length - 1..-1] = [ '-', fname_digest ].join
+          fname[max_length - fname_digest.length - extension.length - 1..-1] = ["-", fname_digest].join
         end
 
-        [ fname, extension ].join
+        [fname, extension].join
       end
 
       # sanitize_paths removes ephemeral values from objects with
       # embedded paths (e.g. an event or a classmap), making events
       # easier to compare across runs.
       def sanitize_paths(h)
-        require 'hashie'
+        require "hashie"
         h.extend(Hashie::Extensions::DeepLocate)
         keys = %i[path location]
         h.deep_locate lambda { |k, _v, o|
           next unless keys.include?(k)
 
-          fix = ->(v) { v.gsub(%r{#{Gem.dir}/gems/.*(?=lib)}, '') }
+          fix = ->(v) { v.gsub(%r{#{Gem.dir}/gems/.*(?=lib)}, "") }
           keys.each { |k| o[k] = fix.call(o[k]) if o[k] }
         }
 
@@ -105,8 +109,8 @@ module AppMap
           headers = event.dig(field, :headers)
           next unless headers
 
-          headers['Date'] = '<instanceof date>' if headers['Date']
-          headers['Server'] = headers['Server'].match(/^(\w+)/)[0] if headers['Server']
+          headers["Date"] = "<instanceof date>" if headers["Date"]
+          headers["Server"] = headers["Server"].match(/^(\w+)/)[0] if headers["Server"]
         end
 
         case event[:event]
@@ -122,8 +126,8 @@ module AppMap
           blank?(headers) ? nil : headers
         end
 
-        unless env['rack.version']
-          warn 'Request headers does not contain rack.version. HTTP_ prefix is not expected.'
+        unless env["rack.version"]
+          warn "Request headers does not contain rack.version. HTTP_ prefix is not expected."
           return finalize_headers.call(env.dup)
         end
 
@@ -131,15 +135,15 @@ module AppMap
         # Apparently, it's following the CGI spec in doing so.
         # https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.18
         matching_headers = env
-                           .select { |k, _v| k.to_s.start_with? 'HTTP_' }
-                           .merge(
-                             'CONTENT_TYPE' => env['CONTENT_TYPE'],
-                             'CONTENT_LENGTH' => env['CONTENT_LENGTH'],
-                             'AUTHORIZATION' => env['AUTHORIZATION']
-                           )
-                           .reject { |_k, v| blank?(v) }
-                           .each_with_object({}) do |kv, memo|
-          key = kv[0].sub(/^HTTP_/, '').split('_').map(&:capitalize).join('-')
+          .select { |k, _v| k.to_s.start_with? "HTTP_" }
+          .merge(
+            "CONTENT_TYPE" => env["CONTENT_TYPE"],
+            "CONTENT_LENGTH" => env["CONTENT_LENGTH"],
+            "AUTHORIZATION" => env["AUTHORIZATION"]
+          )
+          .reject { |_k, v| blank?(v) }
+          .each_with_object({}) do |kv, memo|
+          key = kv[0].sub(/^HTTP_/, "").split("_").map(&:capitalize).join("-")
           value = kv[1]
           memo[key] = value
         end
@@ -147,9 +151,9 @@ module AppMap
       end
 
       def normalize_path(path)
-        is_local_path    = -> { path.index(Dir.pwd) == 0 }
-        is_bundled_path  = -> { path.index(Bundler.bundle_path.to_s) == 0 }
-        is_vendored_path = -> { path.index(File.join(Dir.pwd, 'vendor/bundle')) == 0 }
+        is_local_path = -> { path.index(Dir.pwd) == 0 }
+        is_bundled_path = -> { path.index(Bundler.bundle_path.to_s) == 0 }
+        is_vendored_path = -> { path.index(File.join(Dir.pwd, "vendor/bundle")) == 0 }
 
         if is_local_path.call && !is_bundled_path.call && !is_vendored_path.call
           path[Dir.pwd.length + 1..-1]
@@ -168,13 +172,13 @@ module AppMap
       def extract_test_failure(exception)
         return unless exception
 
-        { message: exception.message }.tap do |test_failure|
+        {message: exception.message}.tap do |test_failure|
           first_location = exception.backtrace_locations&.find do |location|
             !Pathname.new(normalize_path(location.absolute_path || location.path)).absolute?
           end
           if first_location
             test_failure[:location] =
-              [ normalize_path(first_location.path), first_location.lineno ].join(':')
+              [normalize_path(first_location.path), first_location.lineno].join(":")
           end
         end
       end
@@ -182,21 +186,21 @@ module AppMap
       # Convert a Rails-style path from /org/:org_id(.:format)
       # to Swagger-style paths like /org/{org_id}
       def swaggerize_path(path)
-        path = path.split('(.')[0]
-        tokens = path.split('/')
+        path = path.split("(.")[0]
+        tokens = path.split("/")
         tokens.map do |token|
           # stop matching if an ending ) is found
           token.gsub(/^:(.*[^)])/, '{\1}')
-        end.join('/')
+        end.join("/")
       end
 
       # Atomically writes AppMap data to +filename+.
       def write_appmap(filename, appmap)
-        require 'tmpdir'
+        require "tmpdir"
 
         # This is what Ruby Tempfile does; but we don't want the file to be unlinked.
         mode = File::RDWR | File::CREAT | File::EXCL
-        ::Dir::Tmpname.create([ 'appmap_', '.json' ]) do |tmpname|
+        ::Dir::Tmpname.create(["appmap_", ".json"]) do |tmpname|
           tempfile = File.open(tmpname, mode)
           tempfile.write(JSON.generate(appmap))
           tempfile.close
@@ -207,7 +211,7 @@ module AppMap
 
       def color(text, color, bold: false)
         color = Util.const_get(color.to_s.upcase) if color.is_a?(Symbol)
-        bold  = bold ? BOLD : ''
+        bold = bold ? BOLD : ""
         "#{bold}#{color}#{text}#{CLEAR}"
       end
 
@@ -219,24 +223,24 @@ module AppMap
       def underscore(camel_cased_word)
         return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
 
-        word = camel_cased_word.to_s.gsub('::', '/')
+        word = camel_cased_word.to_s.gsub("::", "/")
         # word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_' }#{$2.downcase}" }
         word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
         word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-        word.tr!('-', '_')
+        word.tr!("-", "_")
         word.downcase!
         word
       end
 
       def deep_dup(hash)
-        require 'active_support/core_ext'
+        require "active_support/core_ext"
         hash.deep_dup
       end
 
       def blank?(obj)
         return true if obj.nil?
 
-        return true if obj.is_a?(String) && obj == ''
+        return true if obj.is_a?(String) && obj == ""
 
         return true if obj.respond_to?(:length) && obj.length == 0
 
@@ -257,7 +261,7 @@ module AppMap
       def startup_message(msg)
         if defined?(::Rails) && defined?(::Rails.logger) && ::Rails.logger
           ::Rails.logger.info msg
-        elsif ENV['DEBUG'] == 'true'
+        elsif ENV["DEBUG"] == "true"
           warn msg
         end
 
@@ -265,7 +269,7 @@ module AppMap
       end
 
       def ruby_minor_version
-        @ruby_minor_version ||= RUBY_VERSION.split('.')[0..1].join('.').to_f
+        @ruby_minor_version ||= RUBY_VERSION.split(".")[0..1].join(".").to_f
       end
 
       def gettime
@@ -274,3 +278,7 @@ module AppMap
     end
   end
 end
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/ModuleLength
+# rubocop:enable Metrics/ClassLength
+# rubocop:enable Metrics/AbcSize

--- a/spec/around_recording_spec.rb
+++ b/spec/around_recording_spec.rb
@@ -1,0 +1,32 @@
+require "rails_spec_helper"
+
+describe "around recording", order: :defined do
+  include_context "rails app", "7"
+
+  unless testing_ruby_2?
+    it "creates a recording of a method labeled job.perform" do
+      FileUtils.rm_rf "spec/fixtures/rails7_users_app/tmp/appmap/requests"
+
+      app.prepare_db
+      stdout, stderr, exit_code = app.capture_cmd \
+        "bundle exec rake count_users",
+        "RAILS_ENV" => "development"
+
+      warn stderr if exit_code != 0
+      warn stdout if exit_code != 0
+
+      user_count = stdout.strip
+      expect(user_count).to eq("User count: 0")
+      appmaps_files = Dir.glob("spec/fixtures/rails7_users_app/tmp/appmap/requests/**/*.appmap.json")
+      expect(appmaps_files.count).to eq(1)
+      appmap_file = appmaps_files.first
+      expect(appmap_file).to match(/\d+_perform_now_\d+.appmap\.json\z/)
+      appmap = JSON.parse(File.read(appmap_file))
+      metadata = appmap["metadata"]
+      expect(metadata["recorder"]).to eq(
+        "name" => "command",
+        "type" => "requests"
+      )
+    end
+  end
+end

--- a/spec/fixtures/hook/job.rb
+++ b/spec/fixtures/hook/job.rb
@@ -1,0 +1,13 @@
+class Job
+  # @label job.perform
+  def perform
+    do_work
+  end
+
+  protected_methods
+
+  def do_work
+    puts "Doing work"
+    sleep 0.001
+  end
+end

--- a/spec/fixtures/rails7_users_app/app/jobs/print_user_count_job.rb
+++ b/spec/fixtures/rails7_users_app/app/jobs/print_user_count_job.rb
@@ -1,0 +1,8 @@
+class PrintUserCountJob < ApplicationJob
+  FILENAME = "tmp/user_count.txt"
+
+  def perform
+    count = User.count
+    File.write FILENAME, count
+  end
+end

--- a/spec/fixtures/rails7_users_app/config/environments/development.rb
+++ b/spec/fixtures/rails7_users_app/config/environments/development.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  config.active_job.queue_adapter = :async
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/spec/fixtures/rails7_users_app/config/environments/test.rb
+++ b/spec/fixtures/rails7_users_app/config/environments/test.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/spec/fixtures/rails7_users_app/lib/tasks/count_users.rake
+++ b/spec/fixtures/rails7_users_app/lib/tasks/count_users.rake
@@ -1,0 +1,16 @@
+require "active_job"
+
+task count_users: :environment do
+  FileUtils.rm_f PrintUserCountJob::FILENAME
+
+  # Queue the job
+  PrintUserCountJob.perform_later
+
+  # Wait for the job to complete
+  until File.exist?(PrintUserCountJob::FILENAME)
+    sleep 0.1
+  end
+  count = File.read(PrintUserCountJob::FILENAME).to_i
+  puts "User count: #{count}"
+  sleep 1
+end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -112,9 +112,9 @@ describe "AppMap class Hooking" do
     method = hook_cls.instance_method(:say_default)
 
     require "appmap/hook/method"
-    package = config.lookup_package(hook_cls, method)
-    expect(package).to be
-    hook_method = AppMap::Handler::FunctionHandler.new(package, hook_cls, method)
+    hook_config = config.lookup_hook_config(hook_cls, method)
+    expect(hook_config).to be
+    hook_method = AppMap::Handler::FunctionHandler.new(hook_config.package, hook_cls, method)
     hook_method.activate
 
     tracer = AppMap.tracing.trace

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -1,28 +1,27 @@
-# coding: utf-8
 # frozen_string_literal: true
 
-require 'rails_spec_helper'
-require 'appmap/hook'
-require 'appmap/event'
-require 'diffy'
+require "rails_spec_helper"
+require "appmap/hook"
+require "appmap/event"
+require "diffy"
 
 # Show nulls as the literal +null+, rather than just leaving the field
 # empty. This make some of the expected YAML below easier to
 # understand.
 module ShowYamlNulls
   def visit_NilClass(_o)
-    @emitter.scalar('null', nil, 'tag:yaml.org,2002:null', true, false, Psych::Nodes::Scalar::ANY)
+    @emitter.scalar("null", nil, "tag:yaml.org,2002:null", true, false, Psych::Nodes::Scalar::ANY)
   end
 end
 Psych::Visitors::YAMLTree.prepend(ShowYamlNulls)
 
-describe 'AppMap class Hooking' do
-  include_context 'collect events'
+describe "AppMap class Hooking" do
+  include_context "collect events"
 
   def invoke_test_file(file, setup: nil, packages: nil)
     AppMap.configuration = nil
-    packages ||= [ AppMap::Config::Package.build_from_path(file) ]
-    config = AppMap::Config.new('hook_spec', packages: packages)
+    packages ||= [AppMap::Config::Package.build_from_path(file)]
+    config = AppMap::Config.new("hook_spec", packages: packages)
     AppMap.configuration = config
     tracer = nil
     AppMap::Hook.new(config).enable do
@@ -38,7 +37,7 @@ describe 'AppMap class Hooking' do
       end
     end
 
-    [ config, tracer ]
+    [config, tracer]
   end
 
   def test_hook_behavior(file, events_yaml, setup: nil, &block)
@@ -46,19 +45,19 @@ describe 'AppMap class Hooking' do
 
     events = collect_events(tracer).to_yaml
 
-    expect(Diffy::Diff.new(events_yaml, events).to_s).to eq('') if events_yaml
+    expect(Diffy::Diff.new(events_yaml, events).to_s).to eq("") if events_yaml
 
-    [ config, tracer, events ]
+    [config, tracer, events]
   end
 
   after do
     AppMap.configuration = nil
   end
 
-  it 'excludes named classes and methods' do
-    load 'spec/fixtures/hook/exclude.rb'
-    package = AppMap::Config::Package.build_from_path('spec/fixtures/hook/exclude.rb')
-    config = AppMap::Config.new('hook_spec', packages: [ package ], exclude: %w[ExcludeTest])
+  it "excludes named classes and methods" do
+    load "spec/fixtures/hook/exclude.rb"
+    package = AppMap::Config::Package.build_from_path("spec/fixtures/hook/exclude.rb")
+    config = AppMap::Config.new("hook_spec", packages: [package], exclude: %w[ExcludeTest])
     AppMap.configuration = config
 
     expect(config.never_hook?(ExcludeTest, ExcludeTest.new.method(:instance_method))).to be_truthy
@@ -67,52 +66,52 @@ describe 'AppMap class Hooking' do
 
   it "an instance method named 'call' will be ignored" do
     events_yaml = <<~YAML
-    --- []
+      --- []
     YAML
 
-    _, tracer = test_hook_behavior 'spec/fixtures/hook/method_named_call.rb', events_yaml do
-      expect(MethodNamedCall.new.call(1, 2, 3, 4, 5)).to eq('1 2 3 4 5')
+    _, tracer = test_hook_behavior "spec/fixtures/hook/method_named_call.rb", events_yaml do
+      expect(MethodNamedCall.new.call(1, 2, 3, 4, 5)).to eq("1 2 3 4 5")
     end
   end
 
-  it 'can custom hook and label a function' do
+  it "can custom hook and label a function" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: CustomInstanceMethod
-      :method_id: say_default
-      :path: spec/fixtures/hook/custom_instance_method.rb
-      :lineno: 8
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: CustomInstanceMethod
-        :value: CustomInstance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: default
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: CustomInstanceMethod
+        :method_id: say_default
+        :path: spec/fixtures/hook/custom_instance_method.rb
+        :lineno: 8
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: CustomInstanceMethod
+          :value: CustomInstance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: default
     YAML
 
     config = AppMap::Config.load({
       functions: [
         {
-          package: 'hook_spec',
-          class: 'CustomInstanceMethod',
-          functions: [ :say_default ],
-          labels: ['cowsay']
+          package: "hook_spec",
+          class: "CustomInstanceMethod",
+          functions: [:say_default],
+          labels: ["cowsay"]
         }
       ]
     }.deep_stringify_keys)
 
-    load 'spec/fixtures/hook/custom_instance_method.rb'
+    load "spec/fixtures/hook/custom_instance_method.rb"
     hook_cls = CustomInstanceMethod
     method = hook_cls.instance_method(:say_default)
 
-    require 'appmap/hook/method'
+    require "appmap/hook/method"
     package = config.lookup_package(hook_cls, method)
     expect(package).to be
     hook_method = AppMap::Handler::FunctionHandler.new(package, hook_cls, method)
@@ -121,208 +120,208 @@ describe 'AppMap class Hooking' do
     tracer = AppMap.tracing.trace
     AppMap::Event.reset_id_counter
     begin
-      expect(CustomInstanceMethod.new.say_default).to eq('default')
+      expect(CustomInstanceMethod.new.say_default).to eq("default")
     ensure
       AppMap.tracing.delete(tracer)
     end
 
     events = collect_events(tracer).to_yaml
 
-    expect(Diffy::Diff.new(events_yaml, events).to_s).to eq('')
+    expect(Diffy::Diff.new(events_yaml, events).to_s).to eq("")
     class_map = AppMap.class_map(tracer.event_methods)
-    expect(Diffy::Diff.new(<<~CLASSMAP, YAML.dump(class_map)).to_s).to eq('')
-    ---
-    - :name: hook_spec
-      :type: package
-      :children:
-      - :name: CustomInstanceMethod
-        :type: class
+    expect(Diffy::Diff.new(<<~CLASSMAP, YAML.dump(class_map)).to_s).to eq("")
+      ---
+      - :name: hook_spec
+        :type: package
         :children:
-        - :name: say_default
-          :type: function
-          :location: spec/fixtures/hook/custom_instance_method.rb:8
-          :static: false
-          :labels:
-          - cowsay
+        - :name: CustomInstanceMethod
+          :type: class
+          :children:
+          - :name: say_default
+            :type: function
+            :location: spec/fixtures/hook/custom_instance_method.rb:8
+            :static: false
+            :labels:
+            - cowsay
     CLASSMAP
   end
 
-  it 'parses labels from comments' do
-    _, tracer = invoke_test_file 'spec/fixtures/hook/labels.rb' do
+  it "parses labels from comments" do
+    _, tracer = invoke_test_file "spec/fixtures/hook/labels.rb" do
       ClassWithLabel.new.fn_with_label
     end
     class_map = AppMap.class_map(tracer.event_methods).to_yaml
-    expect(Diffy::Diff.new(<<~YAML, class_map).to_s).to eq('')
-    ---
-    - :name: spec/fixtures/hook
-      :type: package
-      :children:
-      - :name: ClassWithLabel
-        :type: class
+    expect(Diffy::Diff.new(<<~YAML, class_map).to_s).to eq("")
+      ---
+      - :name: spec/fixtures/hook
+        :type: package
         :children:
-        - :name: fn_with_label
-          :type: function
-          :location: spec/fixtures/hook/labels.rb:4
-          :static: false
-          :labels:
-          - has-fn-label
+        - :name: ClassWithLabel
+          :type: class
+          :children:
+          - :name: fn_with_label
+            :type: function
+            :location: spec/fixtures/hook/labels.rb:4
+            :static: false
+            :labels:
+            - has-fn-label
     YAML
   end
 
-  it 'reports sub-folders as distinct packages' do
-    _, tracer = invoke_test_file 'spec/fixtures/hook/sub_packages.rb',
-                                 packages: [ AppMap::Config::Package.build_from_path('spec/fixtures/hook') ] do
+  it "reports sub-folders as distinct packages" do
+    _, tracer = invoke_test_file "spec/fixtures/hook/sub_packages.rb",
+      packages: [AppMap::Config::Package.build_from_path("spec/fixtures/hook")] do
       SubPackages.invoke_a
     end
     class_map = AppMap.class_map(tracer.event_methods).to_yaml
-    expect(Diffy::Diff.new(<<~YAML, class_map).to_s).to eq('')
-    ---
-    - :name: spec/fixtures/hook
-      :type: package
-      :children:
-      - :name: SubPackages
-        :type: class
-        :children:
-        - :name: invoke_a
-          :type: function
-          :location: spec/fixtures/hook/sub_packages.rb:4
-          :static: true
-      - :name: pkg_a
+    expect(Diffy::Diff.new(<<~YAML, class_map).to_s).to eq("")
+      ---
+      - :name: spec/fixtures/hook
         :type: package
         :children:
-        - :name: PkgA
+        - :name: SubPackages
           :type: class
           :children:
-          - :name: A
+          - :name: invoke_a
+            :type: function
+            :location: spec/fixtures/hook/sub_packages.rb:4
+            :static: true
+        - :name: pkg_a
+          :type: package
+          :children:
+          - :name: PkgA
             :type: class
             :children:
-            - :name: hello
-              :type: function
-              :location: spec/fixtures/hook/pkg_a/a.rb:3
-              :static: true
+            - :name: A
+              :type: class
+              :children:
+              - :name: hello
+                :type: function
+                :location: spec/fixtures/hook/pkg_a/a.rb:3
+                :static: true
     YAML
   end
 
-  it 'hooks an instance method that takes no arguments' do
+  it "hooks an instance method that takes no arguments" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: InstanceMethod
-      :method_id: say_default
-      :path: spec/fixtures/hook/instance_method.rb
-      :lineno: 8
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: InstanceMethod
-        :value: Instance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: default
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: InstanceMethod
+        :method_id: say_default
+        :path: spec/fixtures/hook/instance_method.rb
+        :lineno: 8
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: InstanceMethod
+          :value: Instance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: default
     YAML
-    test_hook_behavior 'spec/fixtures/hook/instance_method.rb', events_yaml do
+    test_hook_behavior "spec/fixtures/hook/instance_method.rb", events_yaml do
       expect(InstanceMethod.instance_method(:say_default).parameters).to eq([])
       expect(InstanceMethod.public_instance_method(:say_default).parameters).to eq([])
       expect(InstanceMethod.new.method(:say_default).parameters).to eq([])
       expect(InstanceMethod.new.public_method(:say_default).parameters).to eq([])
       expect { InstanceMethod.new.singleton_method(:say_default) }.to raise_error(NameError)
 
-      expect(InstanceMethod.new.say_default).to eq('default')
+      expect(InstanceMethod.new.say_default).to eq("default")
     end
   end
 
-  it 'collects the methods that are invoked' do
-    _, tracer = invoke_test_file 'spec/fixtures/hook/instance_method.rb' do
+  it "collects the methods that are invoked" do
+    _, tracer = invoke_test_file "spec/fixtures/hook/instance_method.rb" do
       InstanceMethod.new.say_default
     end
-    expect(tracer.event_methods.to_a.map(&:class_name)).to eq([ 'InstanceMethod' ])
-    expect(tracer.event_methods.to_a.map(&:name)).to eq([ InstanceMethod.public_instance_method(:say_default).name ])
+    expect(tracer.event_methods.to_a.map(&:class_name)).to eq(["InstanceMethod"])
+    expect(tracer.event_methods.to_a.map(&:name)).to eq([InstanceMethod.public_instance_method(:say_default).name])
   end
 
-  it 'builds a class map of invoked methods' do
-    _, tracer = invoke_test_file 'spec/fixtures/hook/instance_method.rb' do
+  it "builds a class map of invoked methods" do
+    _, tracer = invoke_test_file "spec/fixtures/hook/instance_method.rb" do
       InstanceMethod.new.say_default
     end
     class_map = AppMap.class_map(tracer.event_methods).to_yaml
-    expect(Diffy::Diff.new(<<~YAML, class_map).to_s).to eq('')
-    ---
-    - :name: spec/fixtures/hook
-      :type: package
-      :children:
-      - :name: InstanceMethod
-        :type: class
+    expect(Diffy::Diff.new(<<~YAML, class_map).to_s).to eq("")
+      ---
+      - :name: spec/fixtures/hook
+        :type: package
         :children:
-        - :name: say_default
-          :type: function
-          :location: spec/fixtures/hook/instance_method.rb:8
-          :static: false
+        - :name: InstanceMethod
+          :type: class
+          :children:
+          - :name: say_default
+            :type: function
+            :location: spec/fixtures/hook/instance_method.rb:8
+            :static: false
     YAML
   end
 
-  it 'does not hook an attr_accessor' do
+  it "does not hook an attr_accessor" do
     events_yaml = <<~YAML
-    --- []
+      --- []
     YAML
-    test_hook_behavior 'spec/fixtures/hook/attr_accessor.rb', events_yaml do
+    test_hook_behavior "spec/fixtures/hook/attr_accessor.rb", events_yaml do
       obj = AttrAccessor.new
-      obj.value = 'foo'
-      expect(obj.value).to eq('foo')
+      obj.value = "foo"
+      expect(obj.value).to eq("foo")
     end
   end
 
-  it 'does not hook a constructor' do
+  it "does not hook a constructor" do
     events_yaml = <<~YAML
-    --- []
+      --- []
     YAML
-    test_hook_behavior 'spec/fixtures/hook/constructor.rb', events_yaml do
-      Constructor.new('foo')
+    test_hook_behavior "spec/fixtures/hook/constructor.rb", events_yaml do
+      Constructor.new("foo")
     end
   end
 
-  it 'records protected instance methods' do
+  it "records protected instance methods" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: ProtectedMethod
-      :method_id: call_protected
-      :path: spec/fixtures/hook/protected_method.rb
-      :lineno: 4
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: ProtectedMethod
-        :value: Protected Method fixture
-    - :id: 2
-      :event: :call
-      :defined_class: ProtectedMethod
-      :method_id: protected_method
-      :path: spec/fixtures/hook/protected_method.rb
-      :lineno: 26
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: ProtectedMethod
-        :value: Protected Method fixture
-    - :id: 3
-      :event: :return
-      :parent_id: 2
-      :return_value:
-        :class: String
-        :value: protected
-    - :id: 4
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: protected
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: ProtectedMethod
+        :method_id: call_protected
+        :path: spec/fixtures/hook/protected_method.rb
+        :lineno: 4
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: ProtectedMethod
+          :value: Protected Method fixture
+      - :id: 2
+        :event: :call
+        :defined_class: ProtectedMethod
+        :method_id: protected_method
+        :path: spec/fixtures/hook/protected_method.rb
+        :lineno: 26
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: ProtectedMethod
+          :value: Protected Method fixture
+      - :id: 3
+        :event: :return
+        :parent_id: 2
+        :return_value:
+          :class: String
+          :value: protected
+      - :id: 4
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: protected
     YAML
     parameters = []
-    test_hook_behavior 'spec/fixtures/hook/protected_method.rb', events_yaml do
+    test_hook_behavior "spec/fixtures/hook/protected_method.rb", events_yaml do
       expect(ProtectedMethod.singleton_method(:call_protected).parameters).to eq(parameters)
       expect(ProtectedMethod.instance_method(:call_protected).parameters).to eq(parameters)
       expect(ProtectedMethod.public_instance_method(:call_protected).parameters).to eq(parameters)
@@ -337,339 +336,339 @@ describe 'AppMap class Hooking' do
       expect(ProtectedMethod.new.public_method(:protected_method).parameters).to eq(parameters)
       expect { ProtectedMethod.new.singleton_method(:protected_method) }.to raise_error(NameError)
 
-      expect(ProtectedMethod.new.call_protected).to eq('protected')
+      expect(ProtectedMethod.new.call_protected).to eq("protected")
     end
   end
 
-  it 'records protected singleton (static) methods' do
+  it "records protected singleton (static) methods" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: ProtectedMethod
-      :method_id: call_protected
-      :path: spec/fixtures/hook/protected_method.rb
-      :lineno: 13
-      :static: true
-      :parameters: []
-      :receiver:
-        :class: Class
-        :value: ProtectedMethod
-    - :id: 2
-      :event: :call
-      :defined_class: ProtectedMethod
-      :method_id: protected_method
-      :path: spec/fixtures/hook/protected_method.rb
-      :lineno: 19
-      :static: true
-      :parameters: []
-      :receiver:
-        :class: Class
-        :value: ProtectedMethod
-    - :id: 3
-      :event: :return
-      :parent_id: 2
-      :return_value:
-        :class: String
-        :value: self.protected
-    - :id: 4
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: self.protected
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: ProtectedMethod
+        :method_id: call_protected
+        :path: spec/fixtures/hook/protected_method.rb
+        :lineno: 13
+        :static: true
+        :parameters: []
+        :receiver:
+          :class: Class
+          :value: ProtectedMethod
+      - :id: 2
+        :event: :call
+        :defined_class: ProtectedMethod
+        :method_id: protected_method
+        :path: spec/fixtures/hook/protected_method.rb
+        :lineno: 19
+        :static: true
+        :parameters: []
+        :receiver:
+          :class: Class
+          :value: ProtectedMethod
+      - :id: 3
+        :event: :return
+        :parent_id: 2
+        :return_value:
+          :class: String
+          :value: self.protected
+      - :id: 4
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: self.protected
     YAML
     parameters = []
-    test_hook_behavior 'spec/fixtures/hook/protected_method.rb', events_yaml do
-      expect(ProtectedMethod.call_protected).to eq('self.protected')
+    test_hook_behavior "spec/fixtures/hook/protected_method.rb", events_yaml do
+      expect(ProtectedMethod.call_protected).to eq("self.protected")
     end
   end
 
-  it 'hooks an instance method that takes an argument' do
+  it "hooks an instance method that takes an argument" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: InstanceMethod
-      :method_id: say_echo
-      :path: spec/fixtures/hook/instance_method.rb
-      :lineno: 12
-      :static: false
-      :parameters:
-      - :name: :arg
-        :class: String
-        :value: echo
-        :kind: :req
-      :receiver:
-        :class: InstanceMethod
-        :value: Instance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: echo
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: InstanceMethod
+        :method_id: say_echo
+        :path: spec/fixtures/hook/instance_method.rb
+        :lineno: 12
+        :static: false
+        :parameters:
+        - :name: :arg
+          :class: String
+          :value: echo
+          :kind: :req
+        :receiver:
+          :class: InstanceMethod
+          :value: Instance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: echo
     YAML
-    test_hook_behavior 'spec/fixtures/hook/instance_method.rb', events_yaml do
-      expect(InstanceMethod.new.say_echo('echo')).to eq('echo')
+    test_hook_behavior "spec/fixtures/hook/instance_method.rb", events_yaml do
+      expect(InstanceMethod.new.say_echo("echo")).to eq("echo")
     end
   end
 
-  it 'hooks an instance method that takes a keyword argument' do
+  it "hooks an instance method that takes a keyword argument" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: InstanceMethod
-      :method_id: say_kw
-      :path: spec/fixtures/hook/instance_method.rb
-      :lineno: 16
-      :static: false
-      :parameters:
-      - :name: :kw
-        :class: String
-        :value: kw
-        :kind: :key
-      :receiver:
-        :class: InstanceMethod
-        :value: Instance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: kw
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: InstanceMethod
+        :method_id: say_kw
+        :path: spec/fixtures/hook/instance_method.rb
+        :lineno: 16
+        :static: false
+        :parameters:
+        - :name: :kw
+          :class: String
+          :value: kw
+          :kind: :key
+        :receiver:
+          :class: InstanceMethod
+          :value: Instance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: kw
     YAML
-    test_hook_behavior 'spec/fixtures/hook/instance_method.rb', events_yaml do
-      expect(InstanceMethod.new.say_kw(kw: 'kw')).to eq('kw')
+    test_hook_behavior "spec/fixtures/hook/instance_method.rb", events_yaml do
+      expect(InstanceMethod.new.say_kw(kw: "kw")).to eq("kw")
     end
   end
 
-  it 'hooks an instance method that takes a default keyword argument' do
+  it "hooks an instance method that takes a default keyword argument" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: InstanceMethod
-      :method_id: say_kw
-      :path: spec/fixtures/hook/instance_method.rb
-      :lineno: 16
-      :static: false
-      :parameters:
-      - :name: :kw
-        :class: NilClass
-        :value: null
-        :kind: :key
-      :receiver:
-        :class: InstanceMethod
-        :value: Instance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: kw
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: InstanceMethod
+        :method_id: say_kw
+        :path: spec/fixtures/hook/instance_method.rb
+        :lineno: 16
+        :static: false
+        :parameters:
+        - :name: :kw
+          :class: NilClass
+          :value: null
+          :kind: :key
+        :receiver:
+          :class: InstanceMethod
+          :value: Instance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: kw
     YAML
-    test_hook_behavior 'spec/fixtures/hook/instance_method.rb', events_yaml do
-      expect(InstanceMethod.new.say_kw).to eq('kw')
+    test_hook_behavior "spec/fixtures/hook/instance_method.rb", events_yaml do
+      expect(InstanceMethod.new.say_kw).to eq("kw")
     end
   end
 
-  it 'hooks an instance method that takes keyword arguments' do
+  it "hooks an instance method that takes keyword arguments" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: InstanceMethod
-      :method_id: say_kws
-      :path: spec/fixtures/hook/instance_method.rb
-      :lineno: 20
-      :static: false
-      :parameters:
-      - :name: :args
-        :class: Array
-        :value: "[4, 5]"
-        :kind: :rest
-        :size: 2
-      - :name: :kw1
-        :class: String
-        :value: one
-        :kind: :keyreq
-      - :name: :kw2
-        :class: Integer
-        :value: '2'
-        :kind: :key
-      - :name: :kws
-        :class: Hash
-        :value: "{:kw3=>:three}"
-        :kind: :keyrest
-        :size: 1
-      :receiver:
-        :class: InstanceMethod
-        :value: Instance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: one2{:kw3=>:three}45
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: InstanceMethod
+        :method_id: say_kws
+        :path: spec/fixtures/hook/instance_method.rb
+        :lineno: 20
+        :static: false
+        :parameters:
+        - :name: :args
+          :class: Array
+          :value: "[4, 5]"
+          :kind: :rest
+          :size: 2
+        - :name: :kw1
+          :class: String
+          :value: one
+          :kind: :keyreq
+        - :name: :kw2
+          :class: Integer
+          :value: '2'
+          :kind: :key
+        - :name: :kws
+          :class: Hash
+          :value: "{:kw3=>:three}"
+          :kind: :keyrest
+          :size: 1
+        :receiver:
+          :class: InstanceMethod
+          :value: Instance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: one2{:kw3=>:three}45
     YAML
-    test_hook_behavior 'spec/fixtures/hook/instance_method.rb', events_yaml do
-      expect(InstanceMethod.new.say_kws(4, 5, kw1: 'one', kw2: 2, kw3: :three)).to eq('one2{:kw3=>:three}45')
+    test_hook_behavior "spec/fixtures/hook/instance_method.rb", events_yaml do
+      expect(InstanceMethod.new.say_kws(4, 5, kw1: "one", kw2: 2, kw3: :three)).to eq("one2{:kw3=>:three}45")
     end
   end
 
-  it 'hooks an instance method that takes a block argument' do
+  it "hooks an instance method that takes a block argument" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: InstanceMethod
-      :method_id: say_block
-      :path: spec/fixtures/hook/instance_method.rb
-      :lineno: 24
-      :static: false
-      :parameters:
-      - :name: :block
-        :class: NilClass
-        :value: null
-        :kind: :block
-      :receiver:
-        :class: InstanceMethod
-        :value: Instance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: albert
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: InstanceMethod
+        :method_id: say_block
+        :path: spec/fixtures/hook/instance_method.rb
+        :lineno: 24
+        :static: false
+        :parameters:
+        - :name: :block
+          :class: NilClass
+          :value: null
+          :kind: :block
+        :receiver:
+          :class: InstanceMethod
+          :value: Instance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: albert
     YAML
-    test_hook_behavior 'spec/fixtures/hook/instance_method.rb', events_yaml do
-      expect(InstanceMethod.new.say_block { 'albert' }).to eq('albert')
+    test_hook_behavior "spec/fixtures/hook/instance_method.rb", events_yaml do
+      expect(InstanceMethod.new.say_block { "albert" }).to eq("albert")
     end
   end
 
-  it 'hooks a singleton method' do
+  it "hooks a singleton method" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: SingletonMethod
-      :method_id: say_default
-      :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 5
-      :static: true
-      :parameters: []
-      :receiver:
-        :class: Class
-        :value: SingletonMethod
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: default
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: SingletonMethod
+        :method_id: say_default
+        :path: spec/fixtures/hook/singleton_method.rb
+        :lineno: 5
+        :static: true
+        :parameters: []
+        :receiver:
+          :class: Class
+          :value: SingletonMethod
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: default
     YAML
-    test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml do
-      expect(SingletonMethod.say_default).to eq('default')
+    test_hook_behavior "spec/fixtures/hook/singleton_method.rb", events_yaml do
+      expect(SingletonMethod.say_default).to eq("default")
     end
   end
 
-  it 'hooks a class method with explicit class name scope' do
+  it "hooks a class method with explicit class name scope" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: SingletonMethod
-      :method_id: say_class_defined
-      :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 10
-      :static: true
-      :parameters: []
-      :receiver:
-        :class: Class
-        :value: SingletonMethod
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: defined with explicit class scope
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: SingletonMethod
+        :method_id: say_class_defined
+        :path: spec/fixtures/hook/singleton_method.rb
+        :lineno: 10
+        :static: true
+        :parameters: []
+        :receiver:
+          :class: Class
+          :value: SingletonMethod
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: defined with explicit class scope
     YAML
-    test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml do
-      expect(SingletonMethod.say_class_defined).to eq('defined with explicit class scope')
+    test_hook_behavior "spec/fixtures/hook/singleton_method.rb", events_yaml do
+      expect(SingletonMethod.say_class_defined).to eq("defined with explicit class scope")
     end
   end
 
   it "hooks a class method with 'self' as the class name scope" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: SingletonMethod
-      :method_id: say_self_defined
-      :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 14
-      :static: true
-      :parameters: []
-      :receiver:
-        :class: Class
-        :value: SingletonMethod
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: defined with self class scope
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: SingletonMethod
+        :method_id: say_self_defined
+        :path: spec/fixtures/hook/singleton_method.rb
+        :lineno: 14
+        :static: true
+        :parameters: []
+        :receiver:
+          :class: Class
+          :value: SingletonMethod
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: defined with self class scope
     YAML
-    test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml do
-      expect(SingletonMethod.say_self_defined).to eq('defined with self class scope')
+    test_hook_behavior "spec/fixtures/hook/singleton_method.rb", events_yaml do
+      expect(SingletonMethod.say_self_defined).to eq("defined with self class scope")
     end
   end
 
-  it 'hooks an included method' do
+  it "hooks an included method" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: SingletonMethod
-      :method_id: added_method
-      :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 21
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: SingletonMethod
-        :value: Singleton Method fixture
-    - :id: 2
-      :event: :call
-      :defined_class: SingletonMethod::AddMethod
-      :method_id: _added_method
-      :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 27
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: SingletonMethod
-        :value: Singleton Method fixture
-    - :id: 3
-      :event: :return
-      :parent_id: 2
-      :return_value:
-        :class: String
-        :value: defined by including a module
-    - :id: 4
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: defined by including a module
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: SingletonMethod
+        :method_id: added_method
+        :path: spec/fixtures/hook/singleton_method.rb
+        :lineno: 21
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: SingletonMethod
+          :value: Singleton Method fixture
+      - :id: 2
+        :event: :call
+        :defined_class: SingletonMethod::AddMethod
+        :method_id: _added_method
+        :path: spec/fixtures/hook/singleton_method.rb
+        :lineno: 27
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: SingletonMethod
+          :value: Singleton Method fixture
+      - :id: 3
+        :event: :return
+        :parent_id: 2
+        :return_value:
+          :class: String
+          :value: defined by including a module
+      - :id: 4
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: defined by including a module
     YAML
 
-    load 'spec/fixtures/hook/singleton_method.rb'
+    load "spec/fixtures/hook/singleton_method.rb"
     setup = -> { SingletonMethod.new.do_include }
-    test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml, setup: setup do |s|
-      expect(s.added_method).to eq('defined by including a module')
+    test_hook_behavior "spec/fixtures/hook/singleton_method.rb", events_yaml, setup: setup do |s|
+      expect(s.added_method).to eq("defined by including a module")
     end
   end
 
@@ -682,138 +681,134 @@ describe 'AppMap class Hooking' do
     # This example will fail if Ruby's behavior changes at some point
     # in the future.
     events_yaml = <<~YAML
-    --- []
+      --- []
     YAML
 
-    load 'spec/fixtures/hook/singleton_method.rb'
+    load "spec/fixtures/hook/singleton_method.rb"
     setup = -> { SingletonMethod.new_with_instance_method }
-    test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml, setup: setup do |s|
+    test_hook_behavior "spec/fixtures/hook/singleton_method.rb", events_yaml, setup: setup do |s|
       # Make sure we're testing the right thing
       say_instance_defined = s.method(:say_instance_defined)
-      expect(say_instance_defined.owner.to_s).to start_with('#<Class:#<SingletonMethod:')
+      expect(say_instance_defined.owner.to_s).to start_with("#<Class:#<SingletonMethod:")
 
       # Verify the native extension works as expected
-      expect(AppMap::Hook.singleton_method_owner_name(say_instance_defined)).to eq('SingletonMethod')
+      expect(AppMap::Hook.singleton_method_owner_name(say_instance_defined)).to eq("SingletonMethod")
 
-      expect(s.say_instance_defined).to eq('defined for an instance')
+      expect(s.say_instance_defined).to eq("defined for an instance")
     end
   end
 
-  it 'hooks a singleton method on an embedded struct' do
+  it "hooks a singleton method on an embedded struct" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: SingletonMethod::STRUCT_TEST
-      :method_id: say_struct_singleton
-      :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 52
-      :static: true
-      :parameters: []
-      :receiver:
-        :class: Class
-        :value: SingletonMethod::STRUCT_TEST
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: singleton for a struct
-    YAML
-
-    test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml do
-      expect(SingletonMethod::STRUCT_TEST.say_struct_singleton).to eq('singleton for a struct')
-    end
-  end
-
-  it 'reports exceptions' do
-    events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: ExceptionMethod
-      :method_id: raise_exception
-      :path: spec/fixtures/hook/exception_method.rb
-      :lineno: 8
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: ExceptionMethod
-        :value: Exception Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :exceptions:
-      - :class: RuntimeError
-        :message: Exception occurred in raise_exception
-        :path: spec/fixtures/hook/exception_method.rb
-        :lineno: 9
-    YAML
-    test_hook_behavior 'spec/fixtures/hook/exception_method.rb', events_yaml do
-      begin
-        ExceptionMethod.new.raise_exception
-      rescue
-        # don't let the exception fail the test
-      end
-    end
-  end
-
-  it 'sanitizes exception messages' do
-    events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: ExceptionMethod
-      :method_id: raise_illegal_utf8_message
-      :path: spec/fixtures/hook/exception_method.rb
-      :lineno: 58
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: ExceptionMethod
-        :value: Exception Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :exceptions:
-      - :class: RuntimeError
-        :message: '809: unexpected token at ''x__=_v_ƶ_2_]__qdI_eǫ4_h΅__z_____D__J2_E______1__ā'''
-        :path: spec/fixtures/hook/exception_method.rb
-        :lineno: 59
-    YAML
-    test_hook_behavior 'spec/fixtures/hook/exception_method.rb', events_yaml do
-      begin
-        ExceptionMethod.new.raise_illegal_utf8_message
-      rescue
-        # don't let the exception fail the test
-      end
-    end
-  end
-
-  context 'string conversions works for the receiver when' do
-    it 'is missing #to_s' do
-      events_yaml = <<~YAML
       ---
       - :id: 1
         :event: :call
-        :defined_class: NoToSMethod
-        :method_id: say_hello
-        :path: spec/fixtures/hook/exception_method.rb
-        :lineno: 32
-        :static: false
+        :defined_class: SingletonMethod::STRUCT_TEST
+        :method_id: say_struct_singleton
+        :path: spec/fixtures/hook/singleton_method.rb
+        :lineno: 52
+        :static: true
         :parameters: []
         :receiver:
           :class: Class
-          :value: NoToSMethod
+          :value: SingletonMethod::STRUCT_TEST
       - :id: 2
         :event: :return
         :parent_id: 1
         :return_value:
           :class: String
-          :value: hello
+          :value: singleton for a struct
+    YAML
+
+    test_hook_behavior "spec/fixtures/hook/singleton_method.rb", events_yaml do
+      expect(SingletonMethod::STRUCT_TEST.say_struct_singleton).to eq("singleton for a struct")
+    end
+  end
+
+  it "reports exceptions" do
+    events_yaml = <<~YAML
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: ExceptionMethod
+        :method_id: raise_exception
+        :path: spec/fixtures/hook/exception_method.rb
+        :lineno: 8
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: ExceptionMethod
+          :value: Exception Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :exceptions:
+        - :class: RuntimeError
+          :message: Exception occurred in raise_exception
+          :path: spec/fixtures/hook/exception_method.rb
+          :lineno: 9
+    YAML
+    test_hook_behavior "spec/fixtures/hook/exception_method.rb", events_yaml do
+      ExceptionMethod.new.raise_exception
+    rescue
+      # don't let the exception fail the test
+    end
+  end
+
+  it "sanitizes exception messages" do
+    events_yaml = <<~YAML
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: ExceptionMethod
+        :method_id: raise_illegal_utf8_message
+        :path: spec/fixtures/hook/exception_method.rb
+        :lineno: 58
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: ExceptionMethod
+          :value: Exception Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :exceptions:
+        - :class: RuntimeError
+          :message: '809: unexpected token at ''x__=_v_ƶ_2_]__qdI_eǫ4_h΅__z_____D__J2_E______1__ā'''
+          :path: spec/fixtures/hook/exception_method.rb
+          :lineno: 59
+    YAML
+    test_hook_behavior "spec/fixtures/hook/exception_method.rb", events_yaml do
+      ExceptionMethod.new.raise_illegal_utf8_message
+    rescue
+      # don't let the exception fail the test
+    end
+  end
+
+  context "string conversions works for the receiver when" do
+    it "is missing #to_s" do
+      events_yaml = <<~YAML
+        ---
+        - :id: 1
+          :event: :call
+          :defined_class: NoToSMethod
+          :method_id: say_hello
+          :path: spec/fixtures/hook/exception_method.rb
+          :lineno: 32
+          :static: false
+          :parameters: []
+          :receiver:
+            :class: Class
+            :value: NoToSMethod
+        - :id: 2
+          :event: :return
+          :parent_id: 1
+          :return_value:
+            :class: String
+            :value: hello
       YAML
 
-      test_hook_behavior 'spec/fixtures/hook/exception_method.rb', events_yaml do
+      test_hook_behavior "spec/fixtures/hook/exception_method.rb", events_yaml do
         inst = NoToSMethod.new
         # sanity check
         expect(inst).not_to respond_to(:to_s)
@@ -821,29 +816,29 @@ describe 'AppMap class Hooking' do
       end
     end
 
-    it 'it is missing #to_s and it raises an exception in #inspect' do
+    it "it is missing #to_s and it raises an exception in #inspect" do
       events_yaml = <<~YAML
-      ---
-      - :id: 1
-        :event: :call
-        :defined_class: InspectRaises
-        :method_id: say_hello
-        :path: spec/fixtures/hook/exception_method.rb
-        :lineno: 42
-        :static: false
-        :parameters: []
-        :receiver:
-          :class: Class
-          :value: "*Error inspecting variable*"
-      - :id: 2
-        :event: :return
-        :parent_id: 1
-        :return_value:
-          :class: String
-          :value: hello
+        ---
+        - :id: 1
+          :event: :call
+          :defined_class: InspectRaises
+          :method_id: say_hello
+          :path: spec/fixtures/hook/exception_method.rb
+          :lineno: 42
+          :static: false
+          :parameters: []
+          :receiver:
+            :class: Class
+            :value: "*Error inspecting variable*"
+        - :id: 2
+          :event: :return
+          :parent_id: 1
+          :return_value:
+            :class: String
+            :value: hello
       YAML
 
-      test_hook_behavior 'spec/fixtures/hook/exception_method.rb', events_yaml do
+      test_hook_behavior "spec/fixtures/hook/exception_method.rb", events_yaml do
         inst = InspectRaises.new
         # sanity check
         expect(inst).not_to respond_to(:to_s)
@@ -851,243 +846,243 @@ describe 'AppMap class Hooking' do
       end
     end
 
-    it 'it raises an exception in #to_s' do
+    it "it raises an exception in #to_s" do
       events_yaml = <<~YAML
-      ---
-      - :id: 1
-        :event: :call
-        :defined_class: ToSRaises
-        :method_id: say_hello
-        :path: spec/fixtures/hook/exception_method.rb
-        :lineno: 52
-        :static: false
-        :parameters: []
-        :receiver:
-          :class: ToSRaises
-          :value: "*Error inspecting variable*"
-      - :id: 2
-        :event: :return
-        :parent_id: 1
-        :return_value:
-          :class: String
-          :value: hello
+        ---
+        - :id: 1
+          :event: :call
+          :defined_class: ToSRaises
+          :method_id: say_hello
+          :path: spec/fixtures/hook/exception_method.rb
+          :lineno: 52
+          :static: false
+          :parameters: []
+          :receiver:
+            :class: ToSRaises
+            :value: "*Error inspecting variable*"
+        - :id: 2
+          :event: :return
+          :parent_id: 1
+          :return_value:
+            :class: String
+            :value: hello
       YAML
 
-      test_hook_behavior 'spec/fixtures/hook/exception_method.rb', events_yaml do
+      test_hook_behavior "spec/fixtures/hook/exception_method.rb", events_yaml do
         ToSRaises.new.say_hello
       end
     end
   end
 
-  it 're-raises exceptions' do
+  it "re-raises exceptions" do
     RSpec::Expectations.configuration.on_potential_false_positives = :nothing
 
-    invoke_test_file 'spec/fixtures/hook/exception_method.rb' do
+    invoke_test_file "spec/fixtures/hook/exception_method.rb" do
       expect { ExceptionMethod.new.raise_exception }.to raise_exception
     end
   end
 
-  context 'ActiveSupport::SecurityUtils.secure_compare' do
-    it 'is hooked' do
-      _, _, events = test_hook_behavior 'spec/fixtures/hook/compare.rb', nil do
-        expect(Compare.compare('string', 'string')).to be_truthy
+  context "ActiveSupport::SecurityUtils.secure_compare" do
+    it "is hooked" do
+      _, _, events = test_hook_behavior "spec/fixtures/hook/compare.rb", nil do
+        expect(Compare.compare("string", "string")).to be_truthy
       end
 
-      secure_compare_event = YAML.load(events).find { |evt| evt[:defined_class] == 'ActiveSupport::SecurityUtils' }
+      secure_compare_event = YAML.load(events).find { |evt| evt[:defined_class] == "ActiveSupport::SecurityUtils" }
       expect(secure_compare_event).to be_truthy
       secure_compare_event.delete(:lineno)
       secure_compare_event.delete(:path)
 
-      expect(Diffy::Diff.new(<<~YAML, secure_compare_event.to_yaml).to_s).to eq('')
-      ---
-      :id: 2
-      :event: :call
-      :defined_class: ActiveSupport::SecurityUtils
-      :method_id: secure_compare
-      :static: true
-      :parameters:
-      - :name: :a
-        :class: String
-        :value: string
-        :kind: :req
-      - :name: :b
-        :class: String
-        :value: string
-        :kind: :req
-      :receiver:
-        :class: Module
-        :value: ActiveSupport::SecurityUtils
+      expect(Diffy::Diff.new(<<~YAML, secure_compare_event.to_yaml).to_s).to eq("")
+        ---
+        :id: 2
+        :event: :call
+        :defined_class: ActiveSupport::SecurityUtils
+        :method_id: secure_compare
+        :static: true
+        :parameters:
+        - :name: :a
+          :class: String
+          :value: string
+          :kind: :req
+        - :name: :b
+          :class: String
+          :value: string
+          :kind: :req
+        :receiver:
+          :class: Module
+          :value: ActiveSupport::SecurityUtils
       YAML
     end
 
-    it 'gets labeled in the classmap' do
+    it "gets labeled in the classmap" do
       classmap_yaml = <<~YAML
-      ---
-      - :name: spec/fixtures/hook/compare.rb
-        :type: package
-        :children:
-        - :name: Compare
-          :type: class
+        ---
+        - :name: spec/fixtures/hook/compare.rb
+          :type: package
           :children:
-          - :name: compare
-            :type: function
-            :location: spec/fixtures/hook/compare.rb:4
-            :static: true
-            :source: |2
-                def self.compare(s1, s2)
-                  ActiveSupport::SecurityUtils.secure_compare(s1, s2)
-                end
-      - :name: active_support
-        :type: package
-        :children:
-        - :name: ActiveSupport
-          :type: class
-          :children:
-          - :name: SecurityUtils
+          - :name: Compare
             :type: class
             :children:
-            - :name: secure_compare
+            - :name: compare
               :type: function
-              :location: lib/active_support/security_utils.rb:26
+              :location: spec/fixtures/hook/compare.rb:4
               :static: true
-              :labels:
-              - security
-              - crypto
-              :comment: |
-                # Constant time string comparison, for variable length strings.
-                #
-                # The values are first processed by SHA256, so that we don't leak length info
-                # via timing attacks.
               :source: |2
-                    def secure_compare(a, b)
-                      fixed_length_secure_compare(::Digest::SHA256.digest(a), ::Digest::SHA256.digest(b)) && a == b
-                    end
-      - :name: openssl
-        :type: package
-        :children:
-        - :name: Digest
-          :type: class
+                  def self.compare(s1, s2)
+                    ActiveSupport::SecurityUtils.secure_compare(s1, s2)
+                  end
+        - :name: active_support
+          :type: package
           :children:
-          - :name: Instance
+          - :name: ActiveSupport
             :type: class
             :children:
-            - :name: digest
-              :type: function
-              :location: Digest::Instance#digest
-              :static: false
-              :labels:
-              - security
-              - crypto
+            - :name: SecurityUtils
+              :type: class
+              :children:
+              - :name: secure_compare
+                :type: function
+                :location: lib/active_support/security_utils.rb:26
+                :static: true
+                :labels:
+                - security
+                - crypto
+                :comment: |
+                  # Constant time string comparison, for variable length strings.
+                  #
+                  # The values are first processed by SHA256, so that we don't leak length info
+                  # via timing attacks.
+                :source: |2
+                      def secure_compare(a, b)
+                        fixed_length_secure_compare(::Digest::SHA256.digest(a), ::Digest::SHA256.digest(b)) && a == b
+                      end
+        - :name: openssl
+          :type: package
+          :children:
+          - :name: Digest
+            :type: class
+            :children:
+            - :name: Instance
+              :type: class
+              :children:
+              - :name: digest
+                :type: function
+                :location: Digest::Instance#digest
+                :static: false
+                :labels:
+                - security
+                - crypto
       YAML
 
-      _, tracer = invoke_test_file 'spec/fixtures/hook/compare.rb' do
-        expect(Compare.compare('string', 'string')).to be_truthy
+      _, tracer = invoke_test_file "spec/fixtures/hook/compare.rb" do
+        expect(Compare.compare("string", "string")).to be_truthy
       end
 
       cm = AppMap::Util.sanitize_paths(AppMap::ClassMap.build_from_methods(tracer.event_methods))
       entry = cm[1][:children][0][:children][0][:children][0]
       # Sanity check, make sure we got the right one
-      expect(entry[:name]).to eq('secure_compare')
+      expect(entry[:name]).to eq("secure_compare")
       expect(entry[:labels]).to eq(%w[crypto.secure_compare])
     end
   end
 
   it "doesn't cause expectations on Time.now to fail" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: InstanceMethod
-      :method_id: say_the_time
-      :path: spec/fixtures/hook/instance_method.rb
-      :lineno: 28
-      :static: false
-      :parameters: []
-      :receiver:
-        :class: InstanceMethod
-        :value: Instance Method fixture
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: '2020-01-01 00:00:00 +0000'
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: InstanceMethod
+        :method_id: say_the_time
+        :path: spec/fixtures/hook/instance_method.rb
+        :lineno: 28
+        :static: false
+        :parameters: []
+        :receiver:
+          :class: InstanceMethod
+          :value: Instance Method fixture
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: String
+          :value: '2020-01-01 00:00:00 +0000'
     YAML
-    test_hook_behavior 'spec/fixtures/hook/instance_method.rb', events_yaml do
-      require 'timecop'
+    test_hook_behavior "spec/fixtures/hook/instance_method.rb", events_yaml do
+      require "timecop"
       begin
-        tz = ENV['TZ']
-        ENV['TZ'] = 'UTC'
-        Timecop.freeze(Time.utc(2020, 01, 01)) do
+        tz = ENV["TZ"]
+        ENV["TZ"] = "UTC"
+        Timecop.freeze(Time.utc(2020, 0o1, 0o1)) do
           expect(Time).to receive(:now).at_least(3).times.and_call_original
           expect(InstanceMethod.new.say_the_time).to be
         end
       ensure
-        ENV['TZ'] = tz
+        ENV["TZ"] = tz
       end
     end
   end
 
-  it 'preserves the arity of hooked methods' do
-    invoke_test_file 'spec/fixtures/hook/instance_method.rb' do
+  it "preserves the arity of hooked methods" do
+    invoke_test_file "spec/fixtures/hook/instance_method.rb" do
       expect(InstanceMethod.instance_method(:say_echo).arity).to be(1)
       expect(InstanceMethod.new.method(:say_echo).arity).to be(1)
     end
   end
 
-  it 'preserves the signature of hooked methods' do
+  it "preserves the signature of hooked methods" do
     parameters = []
     events = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: ReportParameters
-      :method_id: report_parameters
-      :path: spec/fixtures/hook/report_parameters.rb
-      :lineno: 5
-      :static: false
-      :parameters:
-      - :name: :args
-        :class: Array
-        :value: "[foo]"
-        :kind: :rest
-        :size: 1
-      - :name: :kw1
-        :class: String
-        :value: kw1
-        :kind: :keyreq
-      - :name: :kw2
-        :class: NilClass
-        :value: null
-        :kind: :key
-      - :name: :kws
-        :class: Hash
-        :value: "{}"
-        :kind: :keyrest
-        :size: 0
-      :receiver:
-        :class: ReportParameters
-        :value: ReportParameters
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: Array
-        :value: "[[:rest, :args], [:keyreq, :kw1], [:key, :kw2], [:keyrest, :kws]]"
-        :size: 4
+      ---
+      - :id: 1
+        :event: :call
+        :defined_class: ReportParameters
+        :method_id: report_parameters
+        :path: spec/fixtures/hook/report_parameters.rb
+        :lineno: 5
+        :static: false
+        :parameters:
+        - :name: :args
+          :class: Array
+          :value: "[foo]"
+          :kind: :rest
+          :size: 1
+        - :name: :kw1
+          :class: String
+          :value: kw1
+          :kind: :keyreq
+        - :name: :kw2
+          :class: NilClass
+          :value: null
+          :kind: :key
+        - :name: :kws
+          :class: Hash
+          :value: "{}"
+          :kind: :keyrest
+          :size: 0
+        :receiver:
+          :class: ReportParameters
+          :value: ReportParameters
+      - :id: 2
+        :event: :return
+        :parent_id: 1
+        :return_value:
+          :class: Array
+          :value: "[[:rest, :args], [:keyreq, :kw1], [:key, :kw2], [:keyrest, :kws]]"
+          :size: 4
     YAML
     parameters = [[:rest, :args], [:keyreq, :kw1], [:key, :kw2], [:keyrest, :kws]]
-    test_hook_behavior 'spec/fixtures/hook/report_parameters.rb', events do
+    test_hook_behavior "spec/fixtures/hook/report_parameters.rb", events do
       expect(ReportParameters.instance_method(:report_parameters).parameters).to eq(parameters)
-      expect(ReportParameters.new.report_parameters('foo', kw1: 'kw1')).to eq(parameters)
+      expect(ReportParameters.new.report_parameters("foo", kw1: "kw1")).to eq(parameters)
     end
   end
 
-  describe 'kwargs handling' do
+  describe "kwargs handling" do
     if ruby_2?
       # https://github.com/applandinc/appmap-ruby/issues/153
-      it 'empty hash for **kwrest can be proxied as a regular function argument', github_issue: 153 do
-        invoke_test_file 'spec/fixtures/hook/kwargs.rb' do
+      it "empty hash for **kwrest can be proxied as a regular function argument", github_issue: 153 do
+        invoke_test_file "spec/fixtures/hook/kwargs.rb" do
           expect(Kwargs.has_kwrest_calls_no_kwargs(nil, {})).to eq({})
         end
       end
@@ -1098,18 +1093,18 @@ describe 'AppMap class Hooking' do
       #
       # Anonymous rest and keyword rest arguments can now be passed as
       # arguments, instead of just used in method parameters.
-      it 'anonymous rest arguments passed as arguments' do
-        invoke_test_file 'spec/fixtures/hook/anonargs_passed.rb' do
-          expect(AnonArgsPassed.has_anon_rest_calls_anon_rest('param1', 'param2')).to eq('anon')
-          expect(AnonArgsPassed.has_anon_rest_calls_non_anon_rest_first('dummy1', 'param1', 'param2')).to eq(['param1', 'param2'])
-          expect(AnonArgsPassed.has_anon_rest_calls_non_anon_rest_last('param1', 'param2', 'dummy3')).to eq(['param1', 'param2'])
+      it "anonymous rest arguments passed as arguments" do
+        invoke_test_file "spec/fixtures/hook/anonargs_passed.rb" do
+          expect(AnonArgsPassed.has_anon_rest_calls_anon_rest("param1", "param2")).to eq("anon")
+          expect(AnonArgsPassed.has_anon_rest_calls_non_anon_rest_first("dummy1", "param1", "param2")).to eq(["param1", "param2"])
+          expect(AnonArgsPassed.has_anon_rest_calls_non_anon_rest_last("param1", "param2", "dummy3")).to eq(["param1", "param2"])
         end
       end
 
-      it 'anonymous keyword rest arguments passed as arguments' do
-        invoke_test_file 'spec/fixtures/hook/anonkwargs_passed.rb' do
-          expect(AnonKwargsPassed.has_kw_rest_calls_kw_rest({'param1': 1, 'param2': 2})).to eq('kwargs')
-          expect(AnonKwargsPassed.has_kw_rest_calls_kw_rest_last('arg1', 'arg2', 'kwarg1': 1, 'kwarg2': 2)).to eq({'kwarg1': 1, 'kwarg2': 2})
+      it "anonymous keyword rest arguments passed as arguments" do
+        invoke_test_file "spec/fixtures/hook/anonkwargs_passed.rb" do
+          expect(AnonKwargsPassed.has_kw_rest_calls_kw_rest({param1: 1, param2: 2})).to eq("kwargs")
+          expect(AnonKwargsPassed.has_kw_rest_calls_kw_rest_last("arg1", "arg2", kwarg1: 1, kwarg2: 2)).to eq({kwarg1: 1, kwarg2: 2})
         end
       end
 
@@ -1119,45 +1114,45 @@ describe 'AppMap class Hooking' do
       # words, all methods wishing to delegate keyword arguments
       # through *args must now be marked with ruby2_keywords, with no
       # exception.
-      it 'rest arguments passed to keyword arguments' do
-        invoke_test_file 'spec/fixtures/hook/args_to_kwargs.rb' do
-          expect(ArgsToKwArgs.has_args_calls_kwargs('kwarg1': 1, 'kwarg2': 2)).to eq({'kwarg1': 1, 'kwarg2': 2})
+      it "rest arguments passed to keyword arguments" do
+        invoke_test_file "spec/fixtures/hook/args_to_kwargs.rb" do
+          expect(ArgsToKwArgs.has_args_calls_kwargs(kwarg1: 1, kwarg2: 2)).to eq({kwarg1: 1, kwarg2: 2})
         end
       end
 
       # A proc that accepts a single positional argument and keywords
       # will no longer autosplat.
-      it 'proc no longer autosplat' do
-        invoke_test_file 'spec/fixtures/hook/proc_no_autosplat.rb' do
+      it "proc no longer autosplat" do
+        invoke_test_file "spec/fixtures/hook/proc_no_autosplat.rb" do
           expect(ProcNoAutosplat.proc_no_autosplat([1, 2])).to eq([1, 2])
         end
       end
     end
   end
 
-  describe 'prepended override' do
-    it 'does not cause stack overflow error' do
+  describe "prepended override" do
+    it "does not cause stack overflow error" do
       # For the purposes of this test, the code must be statically required, then hooked,
       # then executed.
 
-      require_relative './fixtures/hook/prepended_override'
-      require 'appmap/hook/method'
+      require_relative "fixtures/hook/prepended_override"
+      require "appmap/hook/method"
 
-      pkg = AppMap::Config::Package.new('fixtures/hook/prependend_override')
+      pkg = AppMap::Config::Package.new("fixtures/hook/prependend_override")
       AppMap::Handler::FunctionHandler.new(pkg, PrependedClass, PrependedClass.public_instance_method(:say_hello)).activate
 
       tracer = AppMap.tracing.trace
       AppMap::Event.reset_id_counter
       begin
-        expect(PrependedClass.new.say_hello).to eq('please allow me to introduce myself')
+        expect(PrependedClass.new.say_hello).to eq("please allow me to introduce myself")
       ensure
         AppMap.tracing.delete(tracer)
       end
 
       events = collect_events(tracer)
       expect(events.length).to eq(2)
-      expect(events.first[:method_id]).to eq('say_hello')
-      expect(events.second[:return_value][:value]).to eq('please allow me to introduce myself')
+      expect(events.first[:method_id]).to eq("say_hello")
+      expect(events.second[:return_value][:value]).to eq("please allow me to introduce myself")
     end
   end
 end

--- a/spec/remote_recording_spec.rb
+++ b/spec/remote_recording_spec.rb
@@ -1,23 +1,23 @@
-require 'rails_spec_helper'
+require "rails_spec_helper"
 
-require 'net/http'
+require "net/http"
 
-describe 'remote recording', :order => :defined do
+describe "remote recording", order: :defined do
   def json_body(res)
     JSON.parse(res.body).deep_symbolize_keys
   end
 
-    rails_versions.each do |rails_version|
-      context "with rails #{rails_version}" do
-      include_context 'rails app', rails_version
-      include_context 'Rails app service running'
+  rails_versions.each do |rails_version|
+    context "with rails #{rails_version}" do
+      include_context "rails app", rails_version
+      include_context "Rails app service running"
 
       before(:all) do
-        rails_app_environment = { 'ORM_MODULE' => 'sequel', 'APPMAP_RECORD_REQUESTS' => 'false' }
+        rails_app_environment = {"ORM_MODULE" => "sequel", "APPMAP_RECORD_REQUESTS" => "false"}
         command_options = if testing_ruby_2?
           {}
         else
-          { u: 'puma'}
+          {u: "puma"}
         end
 
         @service_port, @server = start_server(rails_app_environment: rails_app_environment, command_options: command_options)
@@ -27,19 +27,19 @@ describe 'remote recording', :order => :defined do
       end
 
       let(:service_address) { URI("http://localhost:#{@service_port}") }
-      let(:record_path) { '/_appmap/record' }
+      let(:record_path) { "/_appmap/record" }
 
-      it 'returns the recording status' do
+      it "returns the recording status" do
         res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
           http.request(Net::HTTP::Get.new(record_path))
         }
 
         expect(res).to be_a(Net::HTTPOK)
-        expect(res['Content-Type']).to eq('application/json')
+        expect(res["Content-Type"]).to eq("application/json")
         expect(json_body(res)).to eq(enabled: false)
       end
 
-      it 'starts a new recording session' do
+      it "starts a new recording session" do
         res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
           http.request(Net::HTTP::Post.new(record_path))
         }
@@ -47,17 +47,17 @@ describe 'remote recording', :order => :defined do
         expect(res).to be_a(Net::HTTPOK)
       end
 
-      it 'reflects the recording status' do
+      it "reflects the recording status" do
         res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
           http.request(Net::HTTP::Get.new(record_path))
         }
 
         expect(res).to be_a(Net::HTTPOK)
-        expect(res['Content-Type']).to eq('application/json')
+        expect(res["Content-Type"]).to eq("application/json")
         expect(json_body(res)).to eq(enabled: true)
       end
 
-      it 'fails to start a new recording session while recording is already active' do
+      it "fails to start a new recording session while recording is already active" do
         res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
           http.request(Net::HTTP::Post.new(record_path))
         }
@@ -65,19 +65,19 @@ describe 'remote recording', :order => :defined do
         expect(res).to be_a(Net::HTTPConflict)
       end
 
-      it 'stops recording' do
+      it "stops recording" do
         users_res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
-          http.request(Net::HTTP::Get.new(users_path) )
+          http.request(Net::HTTP::Get.new(users_path))
         }
         # Request recording is not enabled by environment variable
-        expect(users_res).to_not include('appmap-file-name')
+        expect(users_res).to_not include("appmap-file-name")
 
         res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
           http.request(Net::HTTP::Delete.new(record_path))
         }
 
         expect(res).to be_a(Net::HTTPOK)
-        expect(res['Content-Type']).to eq('application/json')
+        expect(res["Content-Type"]).to eq("application/json")
 
         data = json_body(res)
         expect(data[:metadata]).to be_truthy
@@ -85,7 +85,7 @@ describe 'remote recording', :order => :defined do
         expect(data[:events].length).to be > 0
       end
 
-      it 'fails to stop recording if there is no active recording session' do
+      it "fails to stop recording if there is no active recording session" do
         res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
           http.request(Net::HTTP::Delete.new(record_path))
         }

--- a/spec/request_recording_spec.rb
+++ b/spec/request_recording_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_spec_helper'
+require "rails_spec_helper"
 
-require 'net/http'
+require "net/http"
 
-describe 'request recording', :order => :defined do
-  include_context 'Rails app pg database', 'spec/fixtures/rails6_users_app'
-  include_context 'Rails app service running'
+describe "request recording", order: :defined do
+  include_context "Rails app pg database", "spec/fixtures/rails6_users_app"
+  include_context "Rails app service running"
 
   before(:all) do
-    @service_port, @server = start_server(rails_app_environment: { 'ORM_MODULE' => 'sequel', 'APPMAP_RECORD_REMOTE' => 'false' })
+    @service_port, @server = start_server(rails_app_environment: {"ORM_MODULE" => "sequel", "APPMAP_RECORD_REMOTE" => "false"})
   end
   after(:all) do
     stop_server(@server)
@@ -15,27 +15,27 @@ describe 'request recording', :order => :defined do
 
   let(:service_address) { URI("http://localhost:#{@service_port}") }
 
-  it 'creates an AppMap for a request' do
+  it "creates an AppMap for a request" do
     # Generate some events
     Net::HTTP.start(service_address.hostname, service_address.port) { |http|
-      http.request(Net::HTTP::Get.new(users_path) )
+      http.request(Net::HTTP::Get.new(users_path))
     }
     Net::HTTP.start(service_address.hostname, service_address.port) { |http|
-      http.request(Net::HTTP::Get.new(users_path) )
+      http.request(Net::HTTP::Get.new(users_path))
     }
     res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
-      http.request(Net::HTTP::Get.new(users_path) )
+      http.request(Net::HTTP::Get.new(users_path))
     }
 
     expect(res).to be_a(Net::HTTPOK)
-    expect(res).to include('appmap-file-name')
-    appmap_file_name = res['AppMap-File-Name']
+    expect(res).to include("appmap-file-name")
+    appmap_file_name = res["AppMap-File-Name"]
     expect(File.exist?(appmap_file_name)).to be(true)
     appmap = JSON.parse(File.read(appmap_file_name))
     # Every event should come from the same thread
-    expect(appmap['events'].map {|evt| evt['thread_id']}.uniq.length).to eq(1)
+    expect(appmap["events"].map { |evt| evt["thread_id"] }.uniq.length).to eq(1)
     # AppMap should contain only one request and response
-    expect(appmap['events'].select {|evt| evt['http_server_request']}.length).to eq(1)
-    expect(appmap['events'].select {|evt| evt['http_server_response']}.length).to eq(1)
+    expect(appmap["events"].select { |evt| evt["http_server_request"] }.length).to eq(1)
+    expect(appmap["events"].select { |evt| evt["http_server_response"] }.length).to eq(1)
   end
 end


### PR DESCRIPTION
Methods labeled `job.perform`, `cli.command`, `message.handle` will automatically start and end a recording, if `APPMAP_RECORD_REQUESTS` is enabled.

Fixes https://github.com/getappmap/appmap-ruby/issues/345
