### PR TITLE
Minitest tagz 20240130

### DIFF
--- a/test/fixtures/minitest_recorder/Gemfile
+++ b/test/fixtures/minitest_recorder/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 gem 'appmap', git: 'applandinc/appmap-ruby', branch: `git rev-parse --abbrev-ref HEAD`.strip
 gem 'byebug'
 gem 'minitest'
+
+gem 'minitest-tagz'

--- a/test/fixtures/minitest_recorder/test/hello_tagged_test.rb
+++ b/test/fixtures/minitest_recorder/test/hello_tagged_test.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'minitest/autorun'
+require 'appmap/minitest'
+require 'hello'
+
+class HelloTaggedTest < ::Minitest::Test
+  tag :noappmap
+  def test_tagged
+    assert_equal 'Hello!', Hello.new.say_hello
+  end
+
+  def test_untagged
+    assert_equal 'Hello!', Hello.new.say_hello
+  end
+end

--- a/test/fixtures/minitest_recorder/test/test_helper.rb
+++ b/test/fixtures/minitest_recorder/test/test_helper.rb
@@ -1,0 +1,2 @@
+require 'minitest/tagz'
+Minitest::Tagz.choose_tags(*ENV['TAGS'].split(',')) if ENV['TAGS']

--- a/test/minitest_test.rb
+++ b/test/minitest_test.rb
@@ -51,4 +51,16 @@ class MinitestTest < Minitest::Test
       assert_equal test_failure['location'], 'test/hello_failed_test.rb:10'
     end
   end
+
+  def test_noappmap_tag
+    perform_minitest_test 'hello_tagged' do
+      # Sanity check, make sure the test file was executed
+      appmap_file = 'tmp/appmap/minitest/Hello_tagged_untagged.appmap.json'
+      assert File.file?(appmap_file), 'appmap output file does not exist'
+
+      # The test tagged with :noappmap should not have generated an AppMap
+      appmap_file = 'tmp/appmap/minitest/Hello_tagged_tagged.appmap.json'
+      assert !File.file?(appmap_file), 'test tagged :noappmap generated an AppMap'
+    end
+  end
 end


### PR DESCRIPTION
Check to see if Minitest::Tagz has been used the add the tag :noappmap
to a test method. If so, don't generate an AppMap for the test.

Fixes #350 .