### PR TITLE
fix: Handle rack apps without engine? method in Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ cache:
 # section called "Pre-installed Ruby versions".  Use versions from
 # that list to not install rvm and ruby each time.
 rvm:
-- 2.6.9
-- 2.7.5
 - 3.0.1 # doesn't show in pre-installed list
 - 3.1.2
 - 3.2.0

--- a/lib/appmap/handler/rails/request_handler.rb
+++ b/lib/appmap/handler/rails/request_handler.rb
@@ -66,7 +66,9 @@ module AppMap
 
               next unless Rails.test_route(app, request)
 
-              return normalized_path request, app.rack_app.routes.router if app.engine?
+              if app.respond_to?(:engine?) && app.engine?
+                return normalized_path request, app.rack_app.routes.router
+              end
 
               return AppMap::Util.swaggerize_path(route.path.spec.to_s)
             end


### PR DESCRIPTION
It seems in some ancient Rails versions there are routes that don't define engine? method which we use to detect engines. Check if the method exists before using.

Note the affected versions are all end of life; the fix is simple but getting a test case would be more complicated so I skipped it.

Fixes #364 